### PR TITLE
ERC721: only owner can burn the token

### DIFF
--- a/src/tokens/ERC721.vy
+++ b/src/tokens/ERC721.vy
@@ -519,11 +519,11 @@ def tokenOfOwnerByIndex(owner: address, index: uint256) -> uint256:
 def burn(token_id: uint256):
     """
     @dev Burns the `token_id` token.
-    @notice Note that the caller must own `token_id`
-            or be an approved operator.
+    @notice Note that the caller must own `token_id`.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "ERC721: caller is not token owner or approved"
+    owner: address = ERC721(self).ownerOf(token_id)
+    assert msg.sender == owner, "ERC721: caller is not token owner"
     self._burn(token_id)
 
 


### PR DESCRIPTION
In current implementation, token id owner or approved owner can burn the respective token.
Limit the burn function to token id owner only.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

<!--
Thank you for using snekmate and taking the time to send a pull request (PR)!

If you are introducing a new feature, please discuss it in an issue or in the discussions section before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

#### PR Checklist

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed in an [issue](https://github.com/pcaversaccio/snekmate/issues) or in the [discussions](https://github.com/pcaversaccio/snekmate/discussions) section.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
