### PR TITLE
🧠 Return `False` Instead of Reverting in `SignatureChecker`

### DIFF
--- a/src/utils/SignatureChecker.vy
+++ b/src/utils/SignatureChecker.vy
@@ -96,9 +96,18 @@ def _is_valid_ERC1271_signature_now(signer: address, hash: bytes32, signature: B
     @return bool The verification whether `signature` is valid
             for the provided data.
     """
-    return_data: Bytes[32] = \
-        raw_call(signer, _abi_encode(hash, signature, method_id=IERC1271_ISVALIDSIGNATURE_SELECTOR), max_outsize=32, is_static_call=True)
-    return ((len(return_data) == 32) and (convert(return_data, bytes32) == convert(IERC1271_ISVALIDSIGNATURE_SELECTOR, bytes32)))
+    success: bool = empty(bool)
+    return_data: Bytes[32] = b""
+    # The following low-level call does not revert, but instead
+    # returns `False` if the callable contract does not implement
+    # the `isValidSignature` function. Since we enforce a length
+    # check of 32 bytes for the return data, we return `False` for
+    # EOA wallets instead of reverting (remember that the EVM always
+    # considers a call to an EOA as successful) because ABI encoding
+    # something with length 0 reverts.
+    success, return_data = \
+        raw_call(signer, _abi_encode(hash, signature, method_id=IERC1271_ISVALIDSIGNATURE_SELECTOR), max_outsize=32, is_static_call=True, revert_on_failure=False)
+    return (success and (len(return_data) == 32) and (convert(return_data, bytes32) == convert(IERC1271_ISVALIDSIGNATURE_SELECTOR, bytes32)))
 
 
 @internal

--- a/src/utils/SignatureChecker.vy
+++ b/src/utils/SignatureChecker.vy
@@ -100,10 +100,11 @@ def _is_valid_ERC1271_signature_now(signer: address, hash: bytes32, signature: B
     return_data: Bytes[32] = b""
     # The following low-level call does not revert, but instead
     # returns `False` if the callable contract does not implement
-    # the `isValidSignature` function. Since we enforce a length
-    # check of 32 bytes for the return data, we return `False` for
-    # EOA wallets instead of reverting (remember that the EVM always
-    # considers a call to an EOA as successful with return data `0x`).
+    # the `isValidSignature` function. Since we perform a length
+    # check of 32 bytes for the return data in the return expression
+    # at the end, we also return `False` for EOA wallets instead
+    # of reverting (remember that the EVM always considers a call
+    # to an EOA as successful with return data `0x`).
     success, return_data = \
         raw_call(signer, _abi_encode(hash, signature, method_id=IERC1271_ISVALIDSIGNATURE_SELECTOR), max_outsize=32, is_static_call=True, revert_on_failure=False)
     return (success and (len(return_data) == 32) and (convert(return_data, bytes32) == convert(IERC1271_ISVALIDSIGNATURE_SELECTOR, bytes32)))

--- a/src/utils/SignatureChecker.vy
+++ b/src/utils/SignatureChecker.vy
@@ -103,8 +103,7 @@ def _is_valid_ERC1271_signature_now(signer: address, hash: bytes32, signature: B
     # the `isValidSignature` function. Since we enforce a length
     # check of 32 bytes for the return data, we return `False` for
     # EOA wallets instead of reverting (remember that the EVM always
-    # considers a call to an EOA as successful) because ABI encoding
-    # something with length 0 reverts.
+    # considers a call to an EOA as successful with return data `0x`).
     success, return_data = \
         raw_call(signer, _abi_encode(hash, signature, method_id=IERC1271_ISVALIDSIGNATURE_SELECTOR), max_outsize=32, is_static_call=True, revert_on_failure=False)
     return (success and (len(return_data) == 32) and (convert(return_data, bytes32) == convert(IERC1271_ISVALIDSIGNATURE_SELECTOR, bytes32)))

--- a/test/utils/SignatureChecker.t.sol
+++ b/test/utils/SignatureChecker.t.sol
@@ -218,7 +218,7 @@ contract SignatureCheckerTest is Test {
         );
     }
 
-    function testEIP1271WithNonExistentFunction() public {
+    function testEIP1271NoIsValidSignatureFunction() public {
         bytes32 hash = keccak256("WAGMI");
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
         bytes memory signature = abi.encodePacked(r, s, v);

--- a/test/utils/SignatureChecker.t.sol
+++ b/test/utils/SignatureChecker.t.sol
@@ -189,11 +189,12 @@ contract SignatureCheckerTest is Test {
             hash,
             signatureInvalid
         );
-        vm.expectRevert(bytes("ECDSA: invalid signature"));
-        signatureChecker.is_valid_ERC1271_signature_now(
-            address(wallet),
-            hash,
-            signatureInvalid
+        assertTrue(
+            !signatureChecker.is_valid_ERC1271_signature_now(
+                address(wallet),
+                hash,
+                signatureInvalid
+            )
         );
     }
 
@@ -211,6 +212,26 @@ contract SignatureCheckerTest is Test {
         assertTrue(
             !signatureChecker.is_valid_ERC1271_signature_now(
                 address(malicious),
+                hash,
+                signature
+            )
+        );
+    }
+
+    function testEIP1271WithNonExistentFunction() public {
+        bytes32 hash = keccak256("WAGMI");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        assertTrue(
+            !signatureChecker.is_valid_signature_now(
+                address(vyperDeployer),
+                hash,
+                signature
+            )
+        );
+        assertTrue(
+            !signatureChecker.is_valid_ERC1271_signature_now(
+                address(vyperDeployer),
                 hash,
                 signature
             )


### PR DESCRIPTION
Fixes #64.
