### PR TITLE
Implement cube root

### DIFF
--- a/src/utils/Math.vy
+++ b/src/utils/Math.vy
@@ -1,0 +1,114 @@
+# @version ^0.3.7
+"""
+@title Gas-Efficient Math
+@license GNU Affero General Public License v3.0
+@author _______
+@notice ______
+"""
+
+
+@external
+@view
+def cbrt(x: uint256) -> uint256:
+    """
+    @notice Calculate the cubic root of a number in 1e18 precision
+    @dev Consumes around 1500 gas units
+    @param x The number to calculate the cubic root of
+    @return The cubic root of the number
+    """
+
+    xx: uint256 = 0
+    if x >= 115792089237316195423570985008687907853269 * 10**18:
+        xx = x
+    elif x >= 115792089237316195423570985008687907853269:
+        xx = unsafe_mul(x, 10**18)
+    else:
+        xx = unsafe_mul(x, 10**36)
+
+    log2x: int256 = self._log2(xx)
+
+    # When we divide log2x by 3, the remainder is (log2x % 3).
+    # So if we just multiply 2**(log2x/3) and discard the remainder to calculate our
+    # guess, the newton method will need more iterations to converge to a solution,
+    # since it is missing that precision. It's a few more calculations now to do less
+    # calculations later:
+    # pow = log2(x) // 3
+    # remainder = log2(x) % 3
+    # initial_guess = 2 ** pow * cbrt(2) ** remainder
+    # substituting -> 2 = 1.26 ≈ 1260 / 1000, we get:
+    #
+    # initial_guess = 2 ** pow * 1260 ** remainder // 1000 ** remainder
+
+    remainder: uint256 = convert(log2x, uint256) % 3
+    a: uint256 = unsafe_div(
+        unsafe_mul(
+            pow_mod256(2, unsafe_div(convert(log2x, uint256), 3)),  # <- pow
+            pow_mod256(1260, remainder),
+        ),
+        pow_mod256(1000, remainder),
+    )
+
+    # Because we chose good initial values for cube roots, 7 newton raphson iterations
+    # are just about sufficient. 6 iterations would result in non-convergences, and 8
+    # would be one too many iterations. Without initial values, the iteration count
+    # can go up to 20 or greater. The iterations are unrolled. This reduces gas costs
+    # but takes up more bytecode:
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+    a = unsafe_div(unsafe_add(unsafe_mul(2, a), unsafe_div(xx, unsafe_mul(a, a))), 3)
+
+    if x >= 115792089237316195423570985008687907853269 * 10**18:
+        return a * 10**12
+    elif x >= 115792089237316195423570985008687907853269:
+        return a * 10**6
+
+    return a
+
+
+@external
+@view
+def log2(x: uint256) -> int256:
+    """
+    @notice Calculate the binary logarithm of a number
+    @param x The number to calculate the binary logarithm of
+    @return The binary logarithm of the number
+    """
+
+    return self._log2(x)
+
+
+@internal
+@pure
+def _log2(x: uint256) -> int256:
+
+    # Compute the binary logarithm of `x`
+
+    # This was inspired from Stanford's 'Bit Twiddling Hacks' by Sean Eron Anderson:
+    # https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog
+    #
+    # More inspiration was derived from:
+    # https://github.com/transmissions11/solmate/blob/main/src/utils/SignedWadMath.sol
+
+    log2x: int256 = 0
+    if x > 340282366920938463463374607431768211455:
+        log2x = 128
+    if unsafe_div(x, shift(2, log2x)) > 18446744073709551615:
+        log2x = log2x | 64
+    if unsafe_div(x, shift(2, log2x)) > 4294967295:
+        log2x = log2x | 32
+    if unsafe_div(x, shift(2, log2x)) > 65535:
+        log2x = log2x | 16
+    if unsafe_div(x, shift(2, log2x)) > 255:
+        log2x = log2x | 8
+    if unsafe_div(x, shift(2, log2x)) > 15:
+        log2x = log2x | 4
+    if unsafe_div(x, shift(2, log2x)) > 3:
+        log2x = log2x | 2
+    if unsafe_div(x, shift(2, log2x)) > 1:
+        log2x = log2x | 1
+
+    return log2x


### PR DESCRIPTION
This pull request adds a cube root implementation to Math.vy (as a part of Math utils proposed in https://github.com/pcaversaccio/snekmate/issues/72).

The cubic root uses methods developed by Solmate, with some additional math. There are some issues when it comes to dealing with very large numbers, for which some precision is sacrificed. Tests for this reduced precision version are written here: https://github.com/curvefi/tricrypto-ng/blob/main/tests/unitary/math/test_cbrt.py (but in python).

