### PR TITLE
🥢 Make In-Contract Interface Names Consistent

### DIFF
--- a/src/utils/Create2Address.vy
+++ b/src/utils/Create2Address.vy
@@ -16,7 +16,7 @@ _COLLISION_OFFSET: constant(bytes1) = 0xFF
 
 # @dev A Vyper contract cannot call directly between two `external` functions.
 # To bypass this, we can use an interface.
-interface ComputeCreate2Address:
+interface ICreate2Address:
     def compute_address(salt: bytes32, bytecode_hash: bytes32, deployer: address) -> address: pure
 
 
@@ -43,7 +43,7 @@ def compute_address_self(salt: bytes32, bytecode_hash: bytes32) -> address:
     @param bytecode_hash The 32-byte bytecode digest of the contract creation bytecode.
     @return address The 20-byte address where a contract will be stored.
     """
-    return ComputeCreate2Address(self).compute_address(salt, bytecode_hash, self)
+    return ICreate2Address(self).compute_address(salt, bytecode_hash, self)
 
 
 @external

--- a/src/utils/CreateAddress.vy
+++ b/src/utils/CreateAddress.vy
@@ -13,7 +13,7 @@
 
 # @dev A Vyper contract cannot call directly between two `external` functions.
 # To bypass this, we can use an interface.
-interface ComputeCreateAddress:
+interface ICreateAddress:
     def compute_address_rlp(deployer: address, nonce: uint256) -> address: pure
 
 
@@ -37,7 +37,7 @@ def compute_address_rlp_self(nonce: uint256) -> address:
     @param nonce The next 32-byte nonce of this contract.
     @return address The 20-byte address where a contract will be stored.
     """
-    return ComputeCreateAddress(self).compute_address_rlp(self, nonce)
+    return ICreateAddress(self).compute_address_rlp(self, nonce)
 
 
 @external

--- a/src/utils/EIP712DomainSeparator.vy
+++ b/src/utils/EIP712DomainSeparator.vy
@@ -30,7 +30,7 @@ _TYPE_HASH: immutable(bytes32)
 
 # @dev A Vyper contract cannot call directly between two `external` functions.
 # To bypass this, we can use an interface.
-interface domainSeparatorV4:
+interface IEIP712DomainSeparator:
     def domain_separator_v4() -> bytes32: view
 
 
@@ -102,7 +102,7 @@ def hash_typed_data_v4(struct_hash: bytes32) -> bytes32:
     @return bytes32 The 32-byte fully encoded EIP712
             message hash for this domain.
     """
-    return self._to_typed_data_hash(domainSeparatorV4(self).domain_separator_v4(), struct_hash)
+    return self._to_typed_data_hash(IEIP712DomainSeparator(self).domain_separator_v4(), struct_hash)
 
 
 @internal


### PR DESCRIPTION
We use the convention `I` & `ContractName` as interface names for in-contract interfaces.