### PR TITLE
📖 Add Remark on `\{id\}` Substring Handling in `_uri` Function of `ERC1155`

### DIFF
--- a/src/tokens/ERC1155.vy
+++ b/src/tokens/ERC1155.vy
@@ -302,7 +302,7 @@ def uri(id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `id`.
-    @notice If the `id` substring is present in the URI,
+    @notice If the `\{id\}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -686,7 +686,7 @@ def _uri(id: uint256) -> String[512]:
     """
     @dev An `internal` helper function that returns the Uniform
          Resource Identifier (URI) for token type `id`.
-    @notice If the `id` substring is present in the URI,
+    @notice If the `\{id\}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -711,6 +711,12 @@ def _uri(id: uint256) -> String[512]:
     # If there is no token URI but a base URI,
     # concatenate the base URI and token ID.
     if (base_uri_length != empty(uint256)):
+        # Please note that for projects where the
+        # substring `\{id\}` is present in the URI
+        # and this URI is to be set as `_BASE_URI`,
+        # it is recommended to remove the following
+        # concatenation and simply return `_BASE_URI`
+        # for easier off-chain handling.
         return concat(_BASE_URI, uint2str(id))
     else:
         return ""

--- a/src/tokens/interfaces/IERC1155MetadataURI.vy
+++ b/src/tokens/interfaces/IERC1155MetadataURI.vy
@@ -50,7 +50,7 @@ def uri(_id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `_id`.
-    @notice If the `_id` substring is present in the URI,
+    @notice If the `\{_id\}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token

--- a/src/tokens/interfaces/IERC1155MetadataURI.vy
+++ b/src/tokens/interfaces/IERC1155MetadataURI.vy
@@ -50,7 +50,7 @@ def uri(_id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `_id`.
-    @notice If the `\{_id\}` substring is present in the URI,
+    @notice If the `\{id\}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token


### PR DESCRIPTION
As title. h/t goes to @jtriley-eth for raising this issue.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/2f876f35-55c5-4503-bcee-460e897b34dd)

