### PR TITLE
🥢 Use Relative Import for `IERC20Permit` in `ERC4626`

### DIFF
--- a/src/extensions/ERC4626.vy
+++ b/src/extensions/ERC4626.vy
@@ -64,7 +64,7 @@ implements: ERC20
 # @dev We import and implement the `IERC20Permit`
 # interface, which is written using standard Vyper
 # syntax.
-import src.tokens.interfaces.IERC20Permit as IERC20Permit
+from ..tokens.interfaces.IERC20Permit import IERC20Permit
 implements: IERC20Permit
 
 


### PR DESCRIPTION
As title. This addresses an `ape` compilation issue discovered [here](https://github.com/vyperlang/vyper/issues/3392).

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/ff71f50e-a14f-4e27-8abc-213936f9706e)