### PR TITLE
🐛 Fix Non-Reverting Fuzz Test in `ERC721.t.sol`

### DIFF
--- a/src/tokens/ERC1155.vy
+++ b/src/tokens/ERC1155.vy
@@ -302,7 +302,7 @@ def uri(id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `id`.
-    @notice If the `\{id\}` substring is present in the URI,
+    @notice If the `id` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -686,7 +686,7 @@ def _uri(id: uint256) -> String[512]:
     """
     @dev An `internal` helper function that returns the Uniform
          Resource Identifier (URI) for token type `id`.
-    @notice If the `\{id\}` substring is present in the URI,
+    @notice If the `id` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -712,9 +712,9 @@ def _uri(id: uint256) -> String[512]:
     # concatenate the base URI and token ID.
     if (base_uri_length != empty(uint256)):
         # Please note that for projects where the
-        # substring `\{id\}` is present in the URI
-        # and this URI is to be set as `_BASE_URI`,
-        # it is recommended to remove the following
+        # substring `id` is present in the URI and
+        # this URI is to be set as `_BASE_URI`, it
+        # is recommended to remove the following
         # concatenation and simply return `_BASE_URI`
         # for easier off-chain handling.
         return concat(_BASE_URI, uint2str(id))

--- a/src/tokens/ERC1155.vy
+++ b/src/tokens/ERC1155.vy
@@ -302,7 +302,7 @@ def uri(id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `id`.
-    @notice If the `id` substring is present in the URI,
+    @notice If the `{id}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -686,7 +686,7 @@ def _uri(id: uint256) -> String[512]:
     """
     @dev An `internal` helper function that returns the Uniform
          Resource Identifier (URI) for token type `id`.
-    @notice If the `id` substring is present in the URI,
+    @notice If the `{id}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token
@@ -712,9 +712,9 @@ def _uri(id: uint256) -> String[512]:
     # concatenate the base URI and token ID.
     if (base_uri_length != empty(uint256)):
         # Please note that for projects where the
-        # substring `id` is present in the URI and
-        # this URI is to be set as `_BASE_URI`, it
-        # is recommended to remove the following
+        # substring `{id}` is present in the URI
+        # and this URI is to be set as `_BASE_URI`,
+        # it is recommended to remove the following
         # concatenation and simply return `_BASE_URI`
         # for easier off-chain handling.
         return concat(_BASE_URI, uint2str(id))

--- a/src/tokens/interfaces/IERC1155MetadataURI.vy
+++ b/src/tokens/interfaces/IERC1155MetadataURI.vy
@@ -50,7 +50,7 @@ def uri(_id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `_id`.
-    @notice If the `\{id\}` substring is present in the URI,
+    @notice If the `id` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token

--- a/src/tokens/interfaces/IERC1155MetadataURI.vy
+++ b/src/tokens/interfaces/IERC1155MetadataURI.vy
@@ -50,7 +50,7 @@ def uri(_id: uint256) -> String[512]:
     """
     @dev Returns the Uniform Resource Identifier (URI)
          for token type `_id`.
-    @notice If the `id` substring is present in the URI,
+    @notice If the `{id}` substring is present in the URI,
             it must be replaced by clients with the actual
             token type ID. Note that the `uri` function must
             not be used to check for the existence of a token

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -1942,7 +1942,8 @@ contract ERC721Test is Test {
             owner != approved &&
                 owner != operator &&
                 owner != zeroAddress &&
-                owner.code.length == 0
+                owner.code.length == 0 &&
+                owner != makeAddr("receiver")
         );
         string memory uri1 = "my_awesome_nft_uri_1";
         string memory uri2 = "my_awesome_nft_uri_2";

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -1984,7 +1984,8 @@ contract ERC721Test is Test {
             owner != approved &&
                 owner != operator &&
                 owner != zeroAddress &&
-                owner.code.length == 0
+                owner.code.length == 0 &&
+                owner != makeAddr("receiver")
         );
         string memory uri1 = "my_awesome_nft_uri_1";
         string memory uri2 = "my_awesome_nft_uri_2";


### PR DESCRIPTION
As title (fixes https://github.com/foundry-rs/foundry/issues/4940). Furthermore, I remove the deprecated Vyper escape sequence `\` (introduced via PR https://github.com/pcaversaccio/snekmate/pull/109) in order to remove any `forge` compilation warnings.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/c1576bea-8484-4de0-b922-99f36ca7f429)