### PR TITLE
🥢Change `AGPL-3.0` to `AGPL-3.0-only`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "devDependencies": {
     "@openzeppelin/merkle-tree": "^1.0.4",
-    "eslint": "^8.42.0",
+    "eslint": "^8.43.0",
     "eslint-config-prettier": "^8.8.0",
     "ethers": "^6.6.0",
     "keccak256": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "description": "State-of-the-art, highly opinionated, hyper-optimised, and secure Vyper smart contract building blocks.",
   "author": "Pascal Marco Caversaccio <pascal.caversaccio@hotmail.ch>",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "keywords": [
     "security",
     "library",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.2"
 description = "State-of-the-art, highly opinionated, hyper-optimised, and secure Vyper smart contract building blocks."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
-license = {text = "AGPL-3.0 License"}
+license = {text = "AGPL-3.0-only License"}
 keywords = ["security", "library", "ethereum", "smart-contracts", "evm", "vyper", "vyper-contracts"]
 authors = [
   {name = "Pascal Marco Caversaccio", email = "pascal.caversaccio@hotmail.ch"},

--- a/src/auth/AccessControl.vy
+++ b/src/auth/AccessControl.vy
@@ -2,7 +2,7 @@
 """
 @title Multi-Role-Based Access Control Functions
 @custom:contract-name AccessControl
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to implement role-based access
         control mechanisms. Roles are referred to by their `bytes32`

--- a/src/auth/Ownable.vy
+++ b/src/auth/Ownable.vy
@@ -2,7 +2,7 @@
 """
 @title Owner-Based Access Control Functions
 @custom:contract-name Ownable
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to implement a basic access
         control mechanism, where there is an account (an owner)

--- a/src/auth/Ownable2Step.vy
+++ b/src/auth/Ownable2Step.vy
@@ -2,7 +2,7 @@
 """
 @title 2-Step Ownership Transfer Functions
 @custom:contract-name Ownable2Step
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to implement a basic access
         control mechanism, where there is an account (an owner)

--- a/src/auth/interfaces/IAccessControl.vy
+++ b/src/auth/interfaces/IAccessControl.vy
@@ -2,7 +2,7 @@
 """
 @title AccessControl Interface Definition
 @custom:contract-name IAccessControl
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The interface definition of `AccessControl`
         to support the ERC-165 detection. In order

--- a/src/extensions/ERC4626.vy
+++ b/src/extensions/ERC4626.vy
@@ -2,7 +2,7 @@
 """
 @title Modern and Gas-Efficient ERC-4626 Tokenised Vault Implementation
 @custom:contract-name ERC4626
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions implement the ERC-4626
         standard interface:

--- a/src/tokens/ERC1155.vy
+++ b/src/tokens/ERC1155.vy
@@ -2,7 +2,7 @@
 """
 @title Modern and Gas-Efficient ERC-1155 Implementation
 @custom:contract-name ERC1155
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @custom:coauthor jtriley.eth
 @notice These functions implement the ERC-1155

--- a/src/tokens/ERC20.vy
+++ b/src/tokens/ERC20.vy
@@ -2,7 +2,7 @@
 """
 @title Modern and Gas-Efficient ERC-20 + EIP-2612 Implementation
 @custom:contract-name ERC20
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions implement the ERC-20
         standard interface:

--- a/src/tokens/ERC721.vy
+++ b/src/tokens/ERC721.vy
@@ -2,7 +2,7 @@
 """
 @title Modern and Gas-Efficient ERC-721 + EIP-4494 Implementation
 @custom:contract-name ERC721
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions implement the ERC-721
         standard interface:

--- a/src/tokens/interfaces/IERC1155.vy
+++ b/src/tokens/interfaces/IERC1155.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-1155 Interface Definition
 @custom:contract-name IERC1155
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The required interface definition of an ERC-1155
         compliant smart contract as defined in:

--- a/src/tokens/interfaces/IERC1155MetadataURI.vy
+++ b/src/tokens/interfaces/IERC1155MetadataURI.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-1155 Optional Metadata Interface Definition
 @custom:contract-name IERC1155MetadataURI
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The metadata extension is optional for an ERC-1155
         smart contract. This allows a smart contract to

--- a/src/tokens/interfaces/IERC1155Receiver.vy
+++ b/src/tokens/interfaces/IERC1155Receiver.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-1155 Token Receiver Interface Definition
 @custom:contract-name IERC1155Receiver
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The interface definition for any contract
         that wants to support safe transfers from

--- a/src/tokens/interfaces/IERC20Permit.vy
+++ b/src/tokens/interfaces/IERC20Permit.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-2612 Interface Definition
 @custom:contract-name IERC20Permit
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The `permit` function implements approvals via
         EIP-712 secp256k1 signatures:

--- a/src/tokens/interfaces/IERC4906.vy
+++ b/src/tokens/interfaces/IERC4906.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-4906 Interface Definition
 @custom:contract-name IERC4906
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The ERC-4906 standard is an extension of EIP-721.
         It adds a `MetadataUpdate` event to EIP-721 tokens.

--- a/src/tokens/interfaces/IERC721Enumerable.vy
+++ b/src/tokens/interfaces/IERC721Enumerable.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-721 Optional Enumeration Interface Definition
 @custom:contract-name IERC721Enumerable
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The enumeration extension is optional for an ERC-721
         smart contract. This allows a contract to publish its

--- a/src/tokens/interfaces/IERC721Metadata.vy
+++ b/src/tokens/interfaces/IERC721Metadata.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-721 Optional Metadata Interface Definition
 @custom:contract-name IERC721Metadata
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The metadata extension is optional for an ERC-721
         smart contract. This allows a smart contract to

--- a/src/tokens/interfaces/IERC721Permit.vy
+++ b/src/tokens/interfaces/IERC721Permit.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-4494 Interface Definition
 @custom:contract-name IERC721Permit
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The `permit` function implements approvals via
         EIP-712 secp256k1 signatures for ERC-721 tokens:

--- a/src/tokens/interfaces/IERC721Receiver.vy
+++ b/src/tokens/interfaces/IERC721Receiver.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-721 Token Receiver Interface Definition
 @custom:contract-name IERC721Receiver
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The interface definition for any contract
         that wants to support safe transfers from

--- a/src/utils/Base64.vy
+++ b/src/utils/Base64.vy
@@ -2,7 +2,7 @@
 """
 @title Base64 Encoding and Decoding Functions
 @custom:contract-name Base64
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to encode bytes or to decode strings
         using the Base64 binary-to-text encoding scheme. For more details,

--- a/src/utils/BatchDistributor.vy
+++ b/src/utils/BatchDistributor.vy
@@ -2,7 +2,7 @@
 """
 @title Batch Sending Both Native and ERC-20 Tokens
 @custom:contract-name BatchDistributor
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used for batch sending
         both native and ERC-20 tokens. The implementation

--- a/src/utils/Create2Address.vy
+++ b/src/utils/Create2Address.vy
@@ -2,7 +2,7 @@
 """
 @title `CREATE2` EVM Opcode Utility Functions for Address Calculations
 @custom:contract-name Create2Address
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to compute in advance the address
         where a smart contract will be deployed if deployed via the

--- a/src/utils/CreateAddress.vy
+++ b/src/utils/CreateAddress.vy
@@ -2,7 +2,7 @@
 """
 @title `CREATE` EVM Opcode Utility Functions for Address Calculations
 @custom:contract-name CreateAddress
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to compute in advance the address
         where a smart contract will be deployed if deployed via the

--- a/src/utils/ECDSA.vy
+++ b/src/utils/ECDSA.vy
@@ -2,7 +2,7 @@
 """
 @title Elliptic Curve Digital Signature Algorithm (ECDSA) Functions
 @custom:contract-name ECDSA
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to verify that a message was signed
         by the holder of the private key of a given address. Additionally,

--- a/src/utils/EIP712DomainSeparator.vy
+++ b/src/utils/EIP712DomainSeparator.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-712 Domain Separator
 @custom:contract-name EIP712DomainSeparator
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions are part of EIP-712: https://eips.ethereum.org/EIPS/eip-712.
         These functions implement the version of encoding known

--- a/src/utils/Math.vy
+++ b/src/utils/Math.vy
@@ -2,7 +2,7 @@
 """
 @title Standard Mathematical Utility Functions
 @custom:contract-name Math
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @custom:coauthor bout3fiddy
 @notice These functions implement standard mathematical utility

--- a/src/utils/MerkleProofVerification.vy
+++ b/src/utils/MerkleProofVerification.vy
@@ -2,7 +2,7 @@
 """
 @title Merkle Tree Proof Verification Functions
 @custom:contract-name MerkleProofVerification
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The Merkle tree and the corresponding proofs can be generated
         using the following JavaScript libraries:

--- a/src/utils/Multicall.vy
+++ b/src/utils/Multicall.vy
@@ -2,7 +2,7 @@
 """
 @title Multicall Functions
 @custom:contract-name Multicall
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice These functions can be used to batch together multiple external
         function calls into one single external function call. Please note

--- a/src/utils/SignatureChecker.vy
+++ b/src/utils/SignatureChecker.vy
@@ -2,7 +2,7 @@
 """
 @title ECDSA and EIP-1271 Signature Verification Functions
 @custom:contract-name SignatureChecker
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice Signature verification helper functions that can be used
         instead of `ECDSA.recover_sig` to seamlessly support both

--- a/src/utils/interfaces/IERC5267.vy
+++ b/src/utils/interfaces/IERC5267.vy
@@ -2,7 +2,7 @@
 """
 @title EIP-5267 Interface Definition
 @custom:contract-name IERC5267
-@license GNU Affero General Public License v3.0
+@license GNU Affero General Public License v3.0 only
 @author pcaversaccio
 @notice The ERC-5267 standard complements the EIP-712 standard
         by standardising how contracts should publish the fields

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.42.0":
-  version "8.42.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.42.0.tgz#484a1d638de2911e6f5a30c12f49c7e4a3270fb6"
-  integrity sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==
+"@eslint/js@8.43.0":
+  version "8.43.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.43.0.tgz#559ca3d9ddbd6bf907ad524320a0d14b85586af0"
+  integrity sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==
 
 "@ethersproject/abi@^5.7.0":
   version "5.7.0"
@@ -345,9 +345,9 @@ acorn-jsx@^5.3.2:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.8.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
-  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
+  integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
 
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
@@ -617,15 +617,15 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.42.0:
-  version "8.42.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.42.0.tgz#7bebdc3a55f9ed7167251fe7259f75219cade291"
-  integrity sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==
+eslint@^8.43.0:
+  version "8.43.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.43.0.tgz#3e8c6066a57097adfd9d390b8fc93075f257a094"
+  integrity sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.4.0"
     "@eslint/eslintrc" "^2.0.3"
-    "@eslint/js" "8.42.0"
+    "@eslint/js" "8.43.0"
     "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -1255,9 +1255,9 @@ secp256k1@^4.0.1:
     node-gyp-build "^4.2.0"
 
 semver@^7.3.8:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
-  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
+  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Since the [`AGPL-3.0`](https://spdx.org/licenses/AGPL-3.0.html) identifier is deprecated, we now use the correct [`AGPL-3.0-only`](https://spdx.org/licenses/AGPL-3.0-only.html) identifier. This PR also bumps `eslint` to version `8.43.0` as well as all submodules are updated to the latest available commit. Note that the [PyPI classifier](https://pypi.org/classifiers) does not change as there are only two available:

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/2b24ed57-c320-47fe-be8f-9bd61191abe8) 

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/0c11f68c-fe91-4e1a-b526-7d32d2c5e801)