### PR TITLE
📖 Add Note on Memory Usage of Dynamic Arrays in `MerkleProofVerification` Contract

### DIFF
--- a/src/snekmate/utils/MerkleProofVerification.vy
+++ b/src/snekmate/utils/MerkleProofVerification.vy
@@ -24,6 +24,10 @@
         https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/test/utils/cryptography/MerkleProof.test.js.
         The implementation is inspired by OpenZeppelin's implementation here:
         https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol.
+@dev Please note that this contract is written in the most agnostic
+     way possible and users should adjust statically allocatable memory
+     to their specific needs before deploying it:
+     https://github.com/pcaversaccio/snekmate/discussions/82.
 """
 
 

--- a/src/snekmate/utils/MerkleProofVerification.vy
+++ b/src/snekmate/utils/MerkleProofVerification.vy
@@ -22,12 +22,14 @@
         OpenZeppelin provides some good examples of how to construct
         Merkle tree proofs correctly:
         https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/test/utils/cryptography/MerkleProof.test.js.
+
+        Please note that this contract is written in the most agnostic
+        way possible and users should adjust statically allocatable memory
+        to their specific needs before deploying it:
+        https://github.com/pcaversaccio/snekmate/discussions/82.
+
         The implementation is inspired by OpenZeppelin's implementation here:
         https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol.
-@dev Please note that this contract is written in the most agnostic
-     way possible and users should adjust statically allocatable memory
-     to their specific needs before deploying it:
-     https://github.com/pcaversaccio/snekmate/discussions/82.
 """
 
 


### PR DESCRIPTION
### 🕓 Changelog

Similarly to #82, the `MerkleProofVerification` functions will run out of gas (with the default gas limits) if the maximum array size (currently set to `max_value(uint16)`) is not adjusted accordingly.

#### 🐶 Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1207115481/photo/bush-viper-snake-black-variation.jpg?s=612x612&w=0&k=20&c=VSEoMLNLfoW2tMhZCFnjFHDJxvbeA2Os8xlpWhtb1Wo=)