### PR TITLE
♻️ Reset `timestamp` in `invariantExecutingNotReadyProposal` Test

### DIFF
--- a/test/governance/TimelockController.t.sol
+++ b/test/governance/TimelockController.t.sol
@@ -4212,8 +4212,11 @@ contract TimelockControllerInvariants is Test {
 
     address private self = address(this);
     address private timelockControllerHandlerAddr;
+    uint256 private initialTimestamp;
 
     function setUp() public {
+        initialTimestamp = block.timestamp;
+
         address[] memory proposers = new address[](1);
         proposers[0] = self;
         address[] memory executors = new address[](1);
@@ -4350,6 +4353,7 @@ contract TimelockControllerInvariants is Test {
      * @dev The execution of a proposal that is not ready is not possible.
      */
     function invariantExecutingNotReadyProposal() public {
+        vm.warp(initialTimestamp);
         uint256[] memory pending = timelockControllerHandler.getPending();
         for (uint256 i = 0; i < pending.length; ++i) {
             // Ensure that the pending proposal cannot be executed.


### PR DESCRIPTION
### 🕓 Changelog

The `foundry` PR https://github.com/foundry-rs/foundry/pull/7819 removes the `preserve_state` config and commits calls by default (i.e. `timestamp` changes will be reflected in the test contract after each call). This new change breaks the invariant `invariantExecutingNotReadyProposal` since calls within invariant runs to the function `TimelockControllerHandler.execute`, which uses `vm.warp(block.timestamp + minDelay);`, will advance the underlying `block.timestamp` of the test contract itself (reverting calls will be treated like a normal call; exactly how it works on-chain right now) and thus can break the assertions in `invariantExecutingNotReadyProposal`. To fix this, we reset the `timestamp` within the invariant `invariantExecutingNotReadyProposal` to the initial `timestamp` of the `setUp` call.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/f5ef47e1-60ea-4552-a935-c2d818f20827)