### PR TITLE
👷 Use `apt-get`-Based Binaries for Yices 2 SMT Solver

### DIFF
--- a/.github/workflows/halmos.yml
+++ b/.github/workflows/halmos.yml
@@ -2,9 +2,9 @@ name: 👁️ Halmos symbolic tests
 
 on:
   schedule:
+    # Run every day at 03:30 UTC.
     - cron: "30 3 * * *"
   workflow_dispatch:
-  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/halmos.yml
+++ b/.github/workflows/halmos.yml
@@ -4,13 +4,14 @@ on:
   schedule:
     - cron: "30 3 * * *"
   workflow_dispatch:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  halmos-tests:
+  halmos:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -55,11 +56,11 @@ jobs:
       - name: Show the Halmos version
         run: halmos --version
 
-      - name: Install Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
       - name: Install Yices 2 SMT solver
-        run: brew install SRI-CSL/sri-csl/yices2
+        run: |
+          sudo add-apt-repository ppa:sri-csl/formal-methods
+          sudo apt-get update
+          sudo apt-get install yices2
 
       - name: Show the Foundry Halmos config
         run: forge config


### PR DESCRIPTION
### 🕓 Changelog

Replace the Homebrew-based Yices 2 SMT solver installation in the `halmos` CI pipeline with `apt-get` (i.e. pulling directly the binaries). This will speed up the installation considerably (Homebrew installs the Yices 2 SMT solver from the source).

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/4634fd52-c0eb-485d-afa4-244f1f342040)