### PR TITLE
fix suggestion for ERC1155TestHalmos.testHalmosAssertNoBackdoor()

### DIFF
--- a/test/halmos.toml
+++ b/test/halmos.toml
@@ -2,7 +2,6 @@
 # Test settings.
 function = "testHalmos"       # Run tests matching the given prefix.
 storage-layout = "generic"    # Set the generic storage layout model.
-test-parallel = true          # Run tests in parallel.
 early-exit = true             # Stop after a counterexample is found.
 ffi = true                    # Enable the foreign function interface (ffi) cheatcode.
 

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -147,8 +147,8 @@ contract ERC1155TestHalmos is Test, SymTest {
             vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
         }
 
-        address[] memory callers;
-        address[] memory others;
+        address[] memory callers = new address[](tokenIds.length);
+        address[] memory others = new address[](tokenIds.length);
         for (uint256 i = 0; i < tokenIds.length; i++) {
             callers[i] = caller;
             others[i] = other;

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -177,22 +177,42 @@ contract ERC1155TestHalmos is Test, SymTest {
                     svm.createBytes(96, "YOLO")
                 )
             );
-        } else if (selector == IERC1155.safeBatchTransferFrom.selector) {
+        } else if (selector == IERC1155.safeBatchTransferFrom.selector
+                || selector == IERC1155Extended.burn_batch.selector
+        ) {
             uint256[] memory ids = new uint256[](5);
             uint256[] memory values = new uint256[](5);
             for (uint256 i = 0; i < ids.length; i++) {
                 ids[i] = svm.createUint256("ids");
                 values[i] = svm.createUint256("values");
             }
-            // solhint-disable-next-line avoid-low-level-calls
-            (success, ) = token.call(
-                abi.encodeWithSelector(
+            bytes memory data;
+            if (selector == IERC1155.safeBatchTransferFrom.selector) {
+                data = abi.encodeWithSelector(
                     selector,
                     svm.createAddress("from"),
                     svm.createAddress("to"),
                     ids,
                     values,
                     svm.createBytes(96, "YOLO")
+                );
+            } else {
+                data = abi.encodeWithSelector(
+                    selector,
+                    svm.createAddress("owner"),
+                    ids,
+                    values
+                );
+            }
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = token.call(data);
+        } else if (selector == IERC1155Extended.set_uri.selector) {
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = token.call(
+                abi.encodeWithSelector(
+                    selector,
+                    svm.createUint256("id"),
+                    svm.createBytes(96, "uri")
                 )
             );
         } else {

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -27,6 +27,10 @@ contract ERC1155TestHalmos is Test, SymTest {
     uint256[] private tokenIds;
     uint256[] private amounts;
 
+    function extcodesize(address addr) internal view returns (uint size) {
+        assembly { size := extcodesize(addr) }
+    }
+
     function setUp() public {
         bytes memory args = abi.encode(_BASE_URI);
         /**
@@ -52,6 +56,15 @@ contract ERC1155TestHalmos is Test, SymTest {
         holders[0] = address(0x1337);
         holders[1] = address(0x31337);
         holders[2] = address(0xbA5eD);
+
+        /**
+         * @dev Assume holders are EOAs to avoid multiple paths that occur due
+         * to safeTransferFrom (specifically `_check_on_erc1155_received`)
+         * depending on contract vs EOA cases.
+         */
+        vm.assume(extcodesize(holders[0]) == 0);
+        vm.assume(extcodesize(holders[1]) == 0);
+        vm.assume(extcodesize(holders[2]) == 0);
 
         tokenIds = new uint256[](5);
         tokenIds[0] = 0;

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -117,86 +117,86 @@ contract ERC1155TestHalmos is Test, SymTest {
     /**
      * @dev Currently commented out due to performance and reverting path issues in Halmos.
      */
-    // function testHalmosAssertNoBackdoor(
-    //     bytes4 selector,
-    //     address caller,
-    //     address other
-    // ) public {
-    //     /**
-    //      * @dev Using a single `assume` with conjunctions would result in the creation of
-    //      * multiple paths, negatively impacting performance.
-    //      */
-    //     vm.assume(caller != other);
-    //     vm.assume(selector != IERC1155Extended._customMint.selector);
-    //     vm.assume(selector != IERC1155Extended.safe_mint.selector);
-    //     vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);
-    //     for (uint256 i = 0; i < holders.length; i++) {
-    //         vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
-    //     }
+    function testHalmosAssertNoBackdoor(
+        bytes4 selector,
+        address caller,
+        address other
+    ) public {
+        /**
+         * @dev Using a single `assume` with conjunctions would result in the creation of
+         * multiple paths, negatively impacting performance.
+         */
+        vm.assume(caller != other);
+        vm.assume(selector != IERC1155Extended._customMint.selector);
+        vm.assume(selector != IERC1155Extended.safe_mint.selector);
+        vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);
+        for (uint256 i = 0; i < holders.length; i++) {
+            vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
+        }
 
-    //     address[] memory callers;
-    //     address[] memory others;
-    //     for (uint256 i = 0; i < tokenIds.length; i++) {
-    //         callers[i] = caller;
-    //         others[i] = other;
-    //     }
+        address[] memory callers;
+        address[] memory others;
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            callers[i] = caller;
+            others[i] = other;
+        }
 
-    //     uint256[] memory oldBalanceCaller = erc1155.balanceOfBatch(
-    //         callers,
-    //         tokenIds
-    //     );
-    //     uint256[] memory oldBalanceOther = erc1155.balanceOfBatch(
-    //         others,
-    //         tokenIds
-    //     );
+        uint256[] memory oldBalanceCaller = erc1155.balanceOfBatch(
+            callers,
+            tokenIds
+        );
+        uint256[] memory oldBalanceOther = erc1155.balanceOfBatch(
+            others,
+            tokenIds
+        );
 
-    //     vm.startPrank(caller);
-    //     bool success;
-    //     if (selector == IERC1155.safeTransferFrom.selector) {
-    //         // solhint-disable-next-line avoid-low-level-calls
-    //         (success, ) = token.call(
-    //             abi.encodeWithSelector(
-    //                 selector,
-    //                 svm.createAddress("from"),
-    //                 svm.createAddress("to"),
-    //                 svm.createUint256("tokenId"),
-    //                 svm.createUint256("amount"),
-    //                 svm.createBytes(96, "YOLO")
-    //             )
-    //         );
-    //     } else if (selector == IERC1155.safeBatchTransferFrom.selector) {
-    //         uint256[] memory ids = new uint256[](5);
-    //         uint256[] memory values = new uint256[](5);
-    //         for (uint256 i = 0; i < ids.length; i++) {
-    //             ids[i] = svm.createUint256("ids");
-    //             values[i] = svm.createUint256("values");
-    //         }
-    //         // solhint-disable-next-line avoid-low-level-calls
-    //         (success, ) = token.call(
-    //             abi.encodeWithSelector(
-    //                 selector,
-    //                 svm.createAddress("from"),
-    //                 svm.createAddress("to"),
-    //                 ids,
-    //                 values,
-    //                 svm.createBytes(96, "YOLO")
-    //             )
-    //         );
-    //     } else {
-    //         bytes memory args = svm.createBytes(1_024, "WAGMI");
-    //         // solhint-disable-next-line avoid-low-level-calls
-    //         (success, ) = address(token).call(abi.encodePacked(selector, args));
-    //     }
-    //     vm.assume(success);
-    //     vm.stopPrank();
+        vm.startPrank(caller);
+        bool success;
+        if (selector == IERC1155.safeTransferFrom.selector) {
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = token.call(
+                abi.encodeWithSelector(
+                    selector,
+                    svm.createAddress("from"),
+                    svm.createAddress("to"),
+                    svm.createUint256("tokenId"),
+                    svm.createUint256("amount"),
+                    svm.createBytes(96, "YOLO")
+                )
+            );
+        } else if (selector == IERC1155.safeBatchTransferFrom.selector) {
+            uint256[] memory ids = new uint256[](5);
+            uint256[] memory values = new uint256[](5);
+            for (uint256 i = 0; i < ids.length; i++) {
+                ids[i] = svm.createUint256("ids");
+                values[i] = svm.createUint256("values");
+            }
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = token.call(
+                abi.encodeWithSelector(
+                    selector,
+                    svm.createAddress("from"),
+                    svm.createAddress("to"),
+                    ids,
+                    values,
+                    svm.createBytes(96, "YOLO")
+                )
+            );
+        } else {
+            bytes memory args = svm.createBytes(1_024, "WAGMI");
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = address(token).call(abi.encodePacked(selector, args));
+        }
+        vm.assume(success);
+        vm.stopPrank();
 
-    //     for (uint256 i = 0; i < tokenIds.length; i++) {
-    //         assert(
-    //             erc1155.balanceOf(caller, tokenIds[i]) <= oldBalanceCaller[i]
-    //         );
-    //         assert(erc1155.balanceOf(other, tokenIds[i]) >= oldBalanceOther[i]);
-    //     }
-    // }
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            assert(
+                erc1155.balanceOf(caller, tokenIds[i]) <= oldBalanceCaller[i]
+            );
+            assert(erc1155.balanceOf(other, tokenIds[i]) >= oldBalanceOther[i]);
+        }
+    }
 
     function testHalmosSafeTransferFrom(
         address caller,

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -143,6 +143,10 @@ contract ERC1155TestHalmos is Test, SymTest {
         vm.assume(selector != IERC1155Extended._customMint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);
+
+        // For convenience, ignore view functions that take dynamic arrays.
+        vm.assume(selector != IERC1155.balanceOfBatch.selector);
+
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
         }

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -98,58 +98,58 @@ contract ERC721TestHalmos is Test, SymTest {
      * @notice Forked and adjusted accordingly from here:
      * https://github.com/a16z/halmos/blob/main/examples/tokens/ERC721/test/ERC721Test.sol.
      */
-    // function testHalmosAssertNoBackdoor(
-    //     bytes4 selector,
-    //     address caller,
-    //     address other
-    // ) public {
-    //     /**
-    //      * @dev Using a single `assume` with conjunctions would result in the creation of
-    //      * multiple paths, negatively impacting performance.
-    //      */
-    //     vm.assume(caller != other);
-    //     vm.assume(selector != IERC721Extended._customMint.selector);
-    //     vm.assume(selector != IERC721Extended.safe_mint.selector);
-    //     for (uint256 i = 0; i < holders.length; i++) {
-    //         vm.assume(!erc721.isApprovedForAll(holders[i], caller));
-    //     }
-    //     for (uint256 i = 0; i < tokenIds.length; i++) {
-    //         vm.assume(erc721.getApproved(tokenIds[i]) != caller);
-    //     }
+    function testHalmosAssertNoBackdoor(
+        bytes4 selector,
+        address caller,
+        address other
+    ) public {
+        /**
+         * @dev Using a single `assume` with conjunctions would result in the creation of
+         * multiple paths, negatively impacting performance.
+         */
+        vm.assume(caller != other);
+        vm.assume(selector != IERC721Extended._customMint.selector);
+        vm.assume(selector != IERC721Extended.safe_mint.selector);
+        for (uint256 i = 0; i < holders.length; i++) {
+            vm.assume(!erc721.isApprovedForAll(holders[i], caller));
+        }
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            vm.assume(erc721.getApproved(tokenIds[i]) != caller);
+        }
 
-    //     uint256 oldBalanceCaller = erc721.balanceOf(caller);
-    //     uint256 oldBalanceOther = erc721.balanceOf(other);
+        uint256 oldBalanceCaller = erc721.balanceOf(caller);
+        uint256 oldBalanceOther = erc721.balanceOf(other);
 
-    //     vm.startPrank(caller);
-    //     bool success;
-    //     if (
-    //         selector ==
-    //         bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"))
-    //     ) {
-    //         // solhint-disable-next-line avoid-low-level-calls
-    //         (success, ) = token.call(
-    //             abi.encodeWithSelector(
-    //                 selector,
-    //                 svm.createAddress("from"),
-    //                 svm.createAddress("to"),
-    //                 svm.createUint256("tokenId"),
-    //                 svm.createBytes(96, "YOLO")
-    //             )
-    //         );
-    //     } else {
-    //         bytes memory args = svm.createBytes(1_024, "WAGMI");
-    //         // solhint-disable-next-line avoid-low-level-calls
-    //         (success, ) = address(token).call(abi.encodePacked(selector, args));
-    //     }
-    //     vm.assume(success);
-    //     vm.stopPrank();
+        vm.startPrank(caller);
+        bool success;
+        if (
+            selector ==
+            bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"))
+        ) {
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = token.call(
+                abi.encodeWithSelector(
+                    selector,
+                    svm.createAddress("from"),
+                    svm.createAddress("to"),
+                    svm.createUint256("tokenId"),
+                    svm.createBytes(96, "YOLO")
+                )
+            );
+        } else {
+            bytes memory args = svm.createBytes(1_024, "WAGMI");
+            // solhint-disable-next-line avoid-low-level-calls
+            (success, ) = address(token).call(abi.encodePacked(selector, args));
+        }
+        vm.assume(success);
+        vm.stopPrank();
 
-    //     uint256 newBalanceCaller = erc721.balanceOf(caller);
-    //     uint256 newBalanceOther = erc721.balanceOf(other);
+        uint256 newBalanceCaller = erc721.balanceOf(caller);
+        uint256 newBalanceOther = erc721.balanceOf(other);
 
-    //     assert(newBalanceCaller <= oldBalanceCaller);
-    //     assert(newBalanceOther >= oldBalanceOther);
-    // }
+        assert(newBalanceCaller <= oldBalanceCaller);
+        assert(newBalanceOther >= oldBalanceOther);
+    }
 
     /**
      * @notice Forked and adjusted accordingly from here:


### PR DESCRIPTION
this draft PR suggests a fix for ERC1155TestHalmos.testHalmosAssertNoBackdoor() to illustrate the root causes of halmos failures.

uncommenting existing tests makes it hard to see the actual changes; reviewing individual commits will help.

please feel free to ignore this and make your own fix.