### PR TITLE
📖 Add Comment on Empty Set in Merkle Multiproof

### DIFF
--- a/src/snekmate/utils/merkle_proof_verification.vy
+++ b/src/snekmate/utils/merkle_proof_verification.vy
@@ -89,7 +89,7 @@ def _multi_proof_verify(proof: DynArray[bytes32, _DYNARRAY_BOUND], proof_flags: 
     @return bool The verification whether `leaves` are simultaneously
             part of a Merkle tree defined by `root`.
     @custom:security It's crucial to recognise that the condition where
-                     `((root == proof[0]) and (len(leaves) == 0)` is
+                     `((root == proof[0]) and (len(leaves) == 0))` is
                      effectively treated as a no-op in {_process_multi_proof}
                      (i.e. it simply returns `proof[0]`) and is thus
                      regarded as a valid multiproof. However, if you are
@@ -156,7 +156,7 @@ def _process_multi_proof(proof: DynArray[bytes32, _DYNARRAY_BOUND], proof_flags:
     @return bytes32 The 32-byte recovered hash by using `leaves`
             and `proof` with a given set of `proof_flags`.
     @custom:security It's crucial to recognise that the condition where
-                     `(len(proof) == 1) and (len(leaves) == 0)` (i.e.
+                     `((len(proof) == 1) and (len(leaves) == 0))` (i.e.
                      the empty set), is effectively treated as a no-op
                      and thus is considered a valid multiproof, returning
                      `proof[0]`. However, if you are not validating the

--- a/src/snekmate/utils/merkle_proof_verification.vy
+++ b/src/snekmate/utils/merkle_proof_verification.vy
@@ -88,6 +88,13 @@ def _multi_proof_verify(proof: DynArray[bytes32, _DYNARRAY_BOUND], proof_flags: 
     @param leaves The 32-byte array containing the leaf hashes.
     @return bool The verification whether `leaves` are simultaneously
             part of a Merkle tree defined by `root`.
+    @custom:security It's crucial to recognise that the condition where
+                     `((root == proof[0]) and (len(leaves) == 0)` is
+                     effectively treated as a no-op in {_process_multi_proof}
+                     (i.e. it simply returns `proof[0]`) and is thus
+                     regarded as a valid multiproof. However, if you are
+                     not validating the leaves in another part of your
+                     code, you may want to consider disallowing this case.
     """
     return self._process_multi_proof(proof, proof_flags, leaves) == root
 
@@ -148,6 +155,13 @@ def _process_multi_proof(proof: DynArray[bytes32, _DYNARRAY_BOUND], proof_flags:
     @param leaves The 32-byte array containing the leaf hashes.
     @return bytes32 The 32-byte recovered hash by using `leaves`
             and `proof` with a given set of `proof_flags`.
+    @custom:security It's crucial to recognise that the condition where
+                     `(len(proof) == 1) and (len(leaves) == 0)` (i.e.
+                     the empty set), is effectively treated as a no-op
+                     and thus is considered a valid multiproof, returning
+                     `proof[0]`. However, if you are not validating the
+                     leaves in another part of your code, you may want to
+                     consider disallowing this case.
     """
     leaves_length: uint256 = len(leaves)
     total_hashes: uint256 = len(proof_flags)

--- a/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
+++ b/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
@@ -66,5 +66,12 @@ def multi_proof_verify(proof: DynArray[bytes32, mp._DYNARRAY_BOUND], proof_flags
     @param leaves The 32-byte array containing the leaf hashes.
     @return bool The verification whether `leaves` are simultaneously
             part of a Merkle tree defined by `root`.
+    @custom:security It's crucial to recognise that the condition where
+                     `((root == proof[0]) and (len(leaves) == 0)` is
+                     effectively treated as a no-op in {mp-_process_multi_proof}
+                     (i.e. it simply returns `proof[0]`) and is thus
+                     regarded as a valid multiproof. However, if you are
+                     not validating the leaves in another part of your
+                     code, you may want to consider disallowing this case.
     """
     return mp._multi_proof_verify(proof, proof_flags, root, leaves)

--- a/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
+++ b/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
@@ -67,7 +67,7 @@ def multi_proof_verify(proof: DynArray[bytes32, mp._DYNARRAY_BOUND], proof_flags
     @return bool The verification whether `leaves` are simultaneously
             part of a Merkle tree defined by `root`.
     @custom:security It's crucial to recognise that the condition where
-                     `((root == proof[0]) and (len(leaves) == 0)` is
+                     `((root == proof[0]) and (len(leaves) == 0))` is
                      effectively treated as a no-op in {mp-_process_multi_proof}
                      (i.e. it simply returns `proof[0]`) and is thus
                      regarded as a valid multiproof. However, if you are


### PR DESCRIPTION
### 🕓 Changelog

It's important to highlight that the condition where `((len(proof) == 1) and (len(leaves) == 0))` (i.e. the empty set), is effectively treated as a no-op in `_process_multi_proof` and thus is considered a valid multiproof, returning `proof[0]`.

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/475896df-9eab-43ab-be51-c61518792076)