### PR TITLE
♻️ Use Native `halmos` `createCalldata` Cheat Code

### DIFF
--- a/.github/workflows/halmos.yml
+++ b/.github/workflows/halmos.yml
@@ -50,7 +50,7 @@ jobs:
         run: pip install setuptools
 
       - name: Install Halmos
-        run: pip install git+https://github.com/a16z/halmos.git@main
+        run: pip install git+https://github.com/a16z/halmos.git@fix/concretize-calldatacopy
 
       - name: Show the Halmos version
         run: halmos --version

--- a/.github/workflows/halmos.yml
+++ b/.github/workflows/halmos.yml
@@ -50,7 +50,7 @@ jobs:
         run: pip install setuptools
 
       - name: Install Halmos
-        run: pip install git+https://github.com/a16z/halmos.git@fix/concretize-calldatacopy
+        run: pip install git+https://github.com/a16z/halmos.git@main
 
       - name: Show the Halmos version
         run: halmos --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
   - [`eip712_domain_separator`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/utils/eip712_domain_separator.vy): Use relative `interfaces` `import`s. ([#263](https://github.com/pcaversaccio/snekmate/pull/263))
   - [`math`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/utils/math.vy): Use mutable `internal` function parameters. ([#267](https://github.com/pcaversaccio/snekmate/pull/267))
 
+### 🥢 Test Coverage
+
+- **Tokens**
+  - [`erc20`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc20.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+  - [`erc721`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc721.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+  - [`erc1155`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc1155.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+
 ### 👀 Full Changelog
 
 - [`v0.1.0...v0.1.1`](https://github.com/pcaversaccio/snekmate/compare/v0.1.0...v0.1.1)

--- a/test/halmos.toml
+++ b/test/halmos.toml
@@ -1,12 +1,13 @@
 [global]
 # Test settings.
 function = "testHalmos"                # Run tests matching the given prefix.
+loop = 5                               # Set the loop unrolling bounds.
 default-bytes-lengths = "0,32,96,1024" # Set the default length candidates for `bytes` and `string` types.
 storage-layout = "generic"             # Set the generic storage layout model.
 ffi = true                             # Enable the foreign function interface (ffi) cheatcode.
 
 # Debugging settings.
-verbose = 2                            # Set the verbosity level for the tests.
+verbose = 1                            # Set the verbosity level for the tests.
 statistics = true                      # Print the statistics.
 early-exit = true                      # Stop after a counterexample is found.
 

--- a/test/halmos.toml
+++ b/test/halmos.toml
@@ -1,7 +1,7 @@
 [global]
 # Test settings.
 function = "testHalmos"                # Run tests matching the given prefix.
-loop = 5                               # Set the loop unrolling bounds.
+loop = 5                               # Set the loop unrolling bound.
 default-bytes-lengths = "0,32,96,1024" # Set the default length candidates for `bytes` and `string` types.
 storage-layout = "generic"             # Set the generic storage layout model.
 ffi = true                             # Enable the foreign function interface (ffi) cheatcode.

--- a/test/halmos.toml
+++ b/test/halmos.toml
@@ -1,14 +1,15 @@
 [global]
 # Test settings.
-function = "testHalmos"       # Run tests matching the given prefix.
-storage-layout = "generic"    # Set the generic storage layout model.
-early-exit = true             # Stop after a counterexample is found.
-ffi = true                    # Enable the foreign function interface (ffi) cheatcode.
+function = "testHalmos"                # Run tests matching the given prefix.
+default-bytes-lengths = "0,32,96,1024" # Set the default length candidates for `bytes` and `string` types.
+storage-layout = "generic"             # Set the generic storage layout model.
+ffi = true                             # Enable the foreign function interface (ffi) cheatcode.
 
 # Debugging settings.
-statistics = true             # Print the statistics.
-verbose = 1                   # Set the verbosity level for the tests.
+verbose = 2                            # Set the verbosity level for the tests.
+statistics = true                      # Print the statistics.
+early-exit = true                      # Stop after a counterexample is found.
 
 # Solver settings.
-solver-command = "yices-smt2" # Use the Yices 2 SMT solver.
-cache-solver = true           # Cache unsatisfiable queries using unsatisfiable cores.
+solver-command = "yices-smt2"          # Use the Yices 2 SMT solver.
+cache-solver = true                    # Cache unsatisfiable queries using unsatisfiable cores.

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -153,7 +153,7 @@ contract ERC1155TestHalmos is Test, SymTest {
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = token.call(
-            svm.createCalldata("IERC1155MetadataURI", "IERC1155MetadataURI")
+            svm.createCalldata("IERC1155MetadataURI.sol", "IERC1155MetadataURI")
         );
         vm.assume(success);
         vm.stopPrank();

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -129,9 +129,6 @@ contract ERC1155TestHalmos is Test, SymTest {
      * @custom:halmos --array-lengths ids=5,values=5
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
-        bytes memory data = svm.createCalldata("IERC1155");
-        bytes4 selector = bytes4(data);
-
         vm.assume(caller != other);
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
@@ -155,7 +152,9 @@ contract ERC1155TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(data);
+        (bool success, ) = token.call(
+            svm.createCalldata("IERC1155MetadataURI")
+        );
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -124,11 +124,7 @@ contract ERC1155TestHalmos is Test, SymTest {
         vm.stopPrank();
     }
 
-    function testHalmosAssertNoBackdoor(
-        bytes4 selector,
-        address caller,
-        address other
-    ) public {
+    function testHalmosAssertNoBackdoor(address caller, address other) public {
         bytes memory data = svm.createCalldata("IERC1155Extended");
         bytes4 selector = bytes4(data);
 

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -153,7 +153,7 @@ contract ERC1155TestHalmos is Test, SymTest {
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = token.call(
-            svm.createCalldata("IERC1155MetadataURI")
+            svm.createCalldata("IERC1155MetadataURI", "IERC1155MetadataURI")
         );
         vm.assume(success);
         vm.stopPrank();

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -6,6 +6,7 @@ import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 import {VyperDeployer} from "utils/VyperDeployer.sol";
 
 import {IERC1155} from "openzeppelin/token/ERC1155/IERC1155.sol";
+import {IERC1155MetadataURI} from "openzeppelin/token/ERC1155/extensions/IERC1155MetadataURI.sol";
 
 import {IERC1155Extended} from "../interfaces/IERC1155Extended.sol";
 
@@ -126,7 +127,7 @@ contract ERC1155TestHalmos is Test, SymTest {
 
     /**
      * Sets the length of the dynamically-sized arrays in the `IERC1155` interface.
-     * @custom:halmos --array-lengths ids=5,values=5
+     * @custom:halmos --array-lengths ids=5,values=5,amounts=5
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
         /**
@@ -145,6 +146,8 @@ contract ERC1155TestHalmos is Test, SymTest {
          * multiple paths, negatively impacting performance.
          */
         vm.assume(caller != other);
+        vm.assume(selector != IERC1155Extended.set_uri.selector);
+        vm.assume(selector != IERC1155Extended.uri.selector);
         vm.assume(selector != IERC1155Extended._customMint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -124,27 +124,15 @@ contract ERC1155TestHalmos is Test, SymTest {
         vm.stopPrank();
     }
 
+    /**
+     * Sets the length of the dynamically-sized arrays in the `IERC1155` interface.
+     * @custom:halmos --array-lengths ids=5,values=5
+     */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
-        /**
-         * @custom:halmos --array-lengths ids=5,values=5,amounts=5
-         */
-        bytes memory data = svm.createCalldata("IERC1155Extended");
+        bytes memory data = svm.createCalldata("IERC1155");
         bytes4 selector = bytes4(data);
 
-        /**
-         * @dev Using a single `assume` with conjunctions would result in the creation of
-         * multiple paths, negatively impacting performance.
-         */
         vm.assume(caller != other);
-        vm.assume(selector != IERC1155Extended._customMint.selector);
-        vm.assume(selector != IERC1155Extended.safe_mint.selector);
-        vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);
-
-        /**
-         * @dev For convenience, ignore `view` functions that use dynamic arrays.
-         */
-        vm.assume(selector != IERC1155.balanceOfBatch.selector);
-
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc1155.isApprovedForAll(holders[i], caller));
         }

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -11,8 +11,8 @@ import {IERC1155MetadataURI} from "openzeppelin/token/ERC1155/extensions/IERC115
 import {IERC1155Extended} from "../interfaces/IERC1155Extended.sol";
 
 /**
- * @dev Sets the timeout (in milliseconds) for solving assertion
- * violation conditions; `0` means no timeout.
+ * @dev Set the timeout (in milliseconds) for solving assertion violation
+ * conditions; `0` means no timeout.
  * @custom:halmos --solver-timeout-assertion 0
  */
 contract ERC1155TestHalmos is Test, SymTest {
@@ -26,6 +26,11 @@ contract ERC1155TestHalmos is Test, SymTest {
     uint256[] private tokenIds;
     uint256[] private amounts;
 
+    /**
+     * @dev Set the timeout (in milliseconds) for solving branching conditions;
+     * `0` means no timeout.
+     * @custom:halmos --solver-timeout-branching 1000
+     */
     function setUp() public {
         bytes memory args = abi.encode(_BASE_URI);
         /**
@@ -126,7 +131,7 @@ contract ERC1155TestHalmos is Test, SymTest {
     }
 
     /**
-     * Sets the length of the dynamically-sized arrays in the `IERC1155` interface.
+     * Set the length of the dynamically-sized arrays in the `IERC1155` interface.
      * @custom:halmos --array-lengths ids=5,values=5,amounts=5
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -146,8 +146,8 @@ contract ERC1155TestHalmos is Test, SymTest {
          * multiple paths, negatively impacting performance.
          */
         vm.assume(caller != other);
+        vm.assume(selector != IERC1155MetadataURI.uri.selector);
         vm.assume(selector != IERC1155Extended.set_uri.selector);
-        vm.assume(selector != IERC1155Extended.uri.selector);
         vm.assume(selector != IERC1155Extended._customMint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint.selector);
         vm.assume(selector != IERC1155Extended.safe_mint_batch.selector);

--- a/test/tokens/halmos/ERC1155TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC1155TestHalmos.t.sol
@@ -125,6 +125,9 @@ contract ERC1155TestHalmos is Test, SymTest {
     }
 
     function testHalmosAssertNoBackdoor(address caller, address other) public {
+        /**
+         * @custom:halmos --array-lengths ids=5,values=5,amounts=5
+         */
         bytes memory data = svm.createCalldata("IERC1155Extended");
         bytes4 selector = bytes4(data);
 

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -94,7 +94,7 @@ contract ERC20TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(svm.createCalldata("IERC20"));
+        (bool success, ) = token.call(svm.createCalldata("IERC20Metadata"));
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -8,8 +8,8 @@ import {VyperDeployer} from "utils/VyperDeployer.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
 /**
- * @dev Sets the timeout (in milliseconds) for solving assertion
- * violation conditions; `0` means no timeout.
+ * @dev Set the timeout (in milliseconds) for solving assertion violation
+ * conditions; `0` means no timeout.
  * @custom:halmos --solver-timeout-assertion 0
  */
 contract ERC20TestHalmos is Test, SymTest {
@@ -25,8 +25,8 @@ contract ERC20TestHalmos is Test, SymTest {
     address[] private holders;
 
     /**
-     * @dev Sets timeout (in milliseconds) for solving branching
-     * conditions; `0` means no timeout.
+     * @dev Set the timeout (in milliseconds) for solving branching conditions;
+     * `0` means no timeout.
      * @custom:halmos --solver-timeout-branching 1000
      */
     function setUpSymbolic(uint256 initialSupply_) public {

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -7,6 +7,8 @@ import {VyperDeployer} from "utils/VyperDeployer.sol";
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
+import {IERC20Extended} from "../interfaces/IERC20Extended.sol";
+
 /**
  * @dev Sets the timeout (in milliseconds) for solving assertion
  * violation conditions; `0` means no timeout.
@@ -86,12 +88,7 @@ contract ERC20TestHalmos is Test, SymTest {
      * @notice Forked and adjusted accordingly from here:
      * https://github.com/a16z/halmos/blob/main/examples/tokens/ERC20/test/ERC20Test.sol.
      */
-    function testHalmosAssertNoBackdoor(
-        bytes4 selector,
-        address caller,
-        address other
-    ) public {
-        bytes memory args = svm.createBytes(1_024, "WAGMI");
+    function testHalmosAssertNoBackdoor(address caller, address other) public {
         vm.assume(other != caller);
 
         uint256 oldBalanceOther = erc20.balanceOf(other);
@@ -99,7 +96,7 @@ contract ERC20TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(abi.encodePacked(selector, args));
+        (bool success, ) = token.call(svm.createCalldata("IERC20Extended"));
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -7,8 +7,6 @@ import {VyperDeployer} from "utils/VyperDeployer.sol";
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
-import {IERC20Extended} from "../interfaces/IERC20Extended.sol";
-
 /**
  * @dev Sets the timeout (in milliseconds) for solving assertion
  * violation conditions; `0` means no timeout.

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -94,7 +94,9 @@ contract ERC20TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(svm.createCalldata("IERC20Metadata"));
+        (bool success, ) = token.call(
+            svm.createCalldata("IERC20Metadata", "IERC20Metadata")
+        );
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -95,7 +95,7 @@ contract ERC20TestHalmos is Test, SymTest {
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = token.call(
-            svm.createCalldata("IERC20Metadata", "IERC20Metadata")
+            svm.createCalldata("IERC20Metadata.sol", "IERC20Metadata")
         );
         vm.assume(success);
         vm.stopPrank();

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -95,7 +95,11 @@ contract ERC20TestHalmos is Test, SymTest {
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = token.call(
-            svm.createCalldata("IERC20Metadata.sol", "IERC20Metadata")
+            /**
+             * @dev To verify the correct behaviour of the Vyper compiler for `view` and `pure`
+             * functions, we include read-only functions in the calldata creation.
+             */
+            svm.createCalldata("IERC20Extended.sol", "IERC20Extended", true)
         );
         vm.assume(success);
         vm.stopPrank();

--- a/test/tokens/halmos/ERC20TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC20TestHalmos.t.sol
@@ -94,7 +94,7 @@ contract ERC20TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(svm.createCalldata("IERC20Extended"));
+        (bool success, ) = token.call(svm.createCalldata("IERC20"));
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -11,8 +11,8 @@ import {IERC721Metadata} from "openzeppelin/token/ERC721/extensions/IERC721Metad
 import {IERC721Extended} from "../interfaces/IERC721Extended.sol";
 
 /**
- * @dev Sets the timeout (in milliseconds) for solving assertion
- * violation conditions; `0` means no timeout.
+ * @dev Set the timeout (in milliseconds) for solving assertion violation
+ * conditions; `0` means no timeout.
  * @custom:halmos --solver-timeout-assertion 0
  */
 contract ERC721TestHalmos is Test, SymTest {
@@ -30,8 +30,8 @@ contract ERC721TestHalmos is Test, SymTest {
     uint256[] private tokenIds;
 
     /**
-     * @dev Sets timeout (in milliseconds) for solving branching
-     * conditions; `0` means no timeout.
+     * @dev Set the timeout (in milliseconds) for solving branching conditions;
+     * `0` means no timeout.
      * @custom:halmos --solver-timeout-branching 1000
      */
     function setUp() public {

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -109,7 +109,9 @@ contract ERC721TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(svm.createCalldata("IERC721Metadata"));
+        (bool success, ) = token.call(
+            svm.createCalldata("IERC721Metadata", "IERC721Metadata")
+        );
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -110,7 +110,7 @@ contract ERC721TestHalmos is Test, SymTest {
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = token.call(
-            svm.createCalldata("IERC721Metadata", "IERC721Metadata")
+            svm.createCalldata("IERC721Metadata.sol", "IERC721Metadata")
         );
         vm.assume(success);
         vm.stopPrank();

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -6,6 +6,7 @@ import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 import {VyperDeployer} from "utils/VyperDeployer.sol";
 
 import {IERC721} from "openzeppelin/token/ERC721/IERC721.sol";
+import {IERC721Metadata} from "openzeppelin/token/ERC721/extensions/IERC721Metadata.sol";
 
 import {IERC721Extended} from "../interfaces/IERC721Extended.sol";
 
@@ -112,6 +113,7 @@ contract ERC721TestHalmos is Test, SymTest {
          * multiple paths, negatively impacting performance.
          */
         vm.assume(caller != other);
+        vm.assume(selector != IERC721Metadata.tokenURI.selector);
         vm.assume(selector != IERC721Extended._customMint.selector);
         vm.assume(selector != IERC721Extended.safe_mint.selector);
         for (uint256 i = 0; i < holders.length; i++) {

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -96,7 +96,24 @@ contract ERC721TestHalmos is Test, SymTest {
      * https://github.com/a16z/halmos/blob/main/examples/tokens/ERC721/test/ERC721Test.sol.
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
+        /**
+         * @dev To verify the correct behaviour of the Vyper compiler for `view` and `pure`
+         * functions, we include read-only functions in the calldata creation.
+         */
+        bytes memory data = svm.createCalldata(
+            "IERC721Extended.sol",
+            "IERC721Extended",
+            true
+        );
+        bytes4 selector = bytes4(data);
+
+        /**
+         * @dev Using a single `assume` with conjunctions would result in the creation of
+         * multiple paths, negatively impacting performance.
+         */
         vm.assume(caller != other);
+        vm.assume(selector != IERC721Extended._customMint.selector);
+        vm.assume(selector != IERC721Extended.safe_mint.selector);
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc721.isApprovedForAll(holders[i], caller));
         }
@@ -109,9 +126,7 @@ contract ERC721TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(
-            svm.createCalldata("IERC721Metadata.sol", "IERC721Metadata")
-        );
+        (bool success, ) = token.call(data);
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -96,16 +96,10 @@ contract ERC721TestHalmos is Test, SymTest {
      * https://github.com/a16z/halmos/blob/main/examples/tokens/ERC721/test/ERC721Test.sol.
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
-        bytes memory data = svm.createCalldata("IERC721Extended");
+        bytes memory data = svm.createCalldata("IERC721");
         bytes4 selector = bytes4(data);
 
-        /**
-         * @dev Using a single `assume` with conjunctions would result in the creation of
-         * multiple paths, negatively impacting performance.
-         */
         vm.assume(caller != other);
-        vm.assume(selector != IERC721Extended._customMint.selector);
-        vm.assume(selector != IERC721Extended.safe_mint.selector);
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc721.isApprovedForAll(holders[i], caller));
         }

--- a/test/tokens/halmos/ERC721TestHalmos.t.sol
+++ b/test/tokens/halmos/ERC721TestHalmos.t.sol
@@ -96,9 +96,6 @@ contract ERC721TestHalmos is Test, SymTest {
      * https://github.com/a16z/halmos/blob/main/examples/tokens/ERC721/test/ERC721Test.sol.
      */
     function testHalmosAssertNoBackdoor(address caller, address other) public {
-        bytes memory data = svm.createCalldata("IERC721");
-        bytes4 selector = bytes4(data);
-
         vm.assume(caller != other);
         for (uint256 i = 0; i < holders.length; i++) {
             vm.assume(!erc721.isApprovedForAll(holders[i], caller));
@@ -112,7 +109,7 @@ contract ERC721TestHalmos is Test, SymTest {
 
         vm.startPrank(caller);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = token.call(data);
+        (bool success, ) = token.call(svm.createCalldata("IERC721Metadata"));
         vm.assume(success);
         vm.stopPrank();
 

--- a/test/utils/halmos/MathTestHalmos.t.sol
+++ b/test/utils/halmos/MathTestHalmos.t.sol
@@ -11,8 +11,8 @@ import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {IMath} from "../interfaces/IMath.sol";
 
 /**
- * @dev Sets the timeout (in milliseconds) for solving assertion
- * violation conditions; `0` means no timeout.
+ * @dev Set the timeout (in milliseconds) for solving assertion violation
+ * conditions; `0` means no timeout.
  * @custom:halmos --solver-timeout-assertion 0
  */
 contract MathTestHalmos is Test, SymTest {
@@ -21,8 +21,8 @@ contract MathTestHalmos is Test, SymTest {
     IMath private math;
 
     /**
-     * @dev Sets timeout (in milliseconds) for solving branching
-     * conditions; `0` means no timeout.
+     * @dev Set the timeout (in milliseconds) for solving branching conditions;
+     * `0` means no timeout.
      * @custom:halmos --solver-timeout-branching 1000
      */
     function setUp() public {
@@ -65,9 +65,9 @@ contract MathTestHalmos is Test, SymTest {
     }
 
     /**
-     * @dev Currently commented out, as the timeout for the Z3 solver does not work for
-     * the queries of this test, where the Z3 solver is constantly running and consumes
-     * a lot of memory, causing the CI to crash due to out of memory.
+     * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
+     * and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertMulDiv(
     //     uint256 x,
@@ -112,27 +112,27 @@ contract MathTestHalmos is Test, SymTest {
     }
 
     /**
-     * @dev Currently commented out, as the timeout for the Z3 solver does not work for
-     * the queries of this test, where the Z3 solver is constantly running and consumes
-     * a lot of memory, causing the CI to crash due to out of memory.
+     * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
+     * and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadLn(int256 x) public view {
     //     assertEq(math.wad_ln(x), FixedPointMathLib.lnWad(x));
     // }
 
     /**
-     * @dev Currently commented out, as the timeout for the Z3 solver does not work for
-     * the queries of this test, where the Z3 solver is constantly running and consumes
-     * a lot of memory, causing the CI to crash due to out of memory.
+     * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
+     * and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadExp(int256 x) public view {
     //     assertEq(math.wad_exp(x), FixedPointMathLib.expWad(x));
     // }
 
     /**
-     * @dev Currently commented out, as the timeout for the Z3 solver does not work for
-     * the queries of this test, where the Z3 solver is constantly running and consumes
-     * a lot of memory, causing the CI to crash due to out of memory.
+     * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
+     * and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertCbrt(uint256 x, bool roundup) public view {
     //     if (!roundup) {
@@ -146,9 +146,9 @@ contract MathTestHalmos is Test, SymTest {
     // }
 
     /**
-     * @dev Currently commented out, as the timeout for the Z3 solver does not work for
-     * the queries of this test, where the Z3 solver is constantly running and consumes
-     * a lot of memory, causing the CI to crash due to out of memory.
+     * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
+     * and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadCbrt(uint256 x) public view {
     //     assertEq(math.wad_cbrt(x), FixedPointMathLib.cbrtWad(x));

--- a/test/utils/halmos/MathTestHalmos.t.sol
+++ b/test/utils/halmos/MathTestHalmos.t.sol
@@ -66,8 +66,8 @@ contract MathTestHalmos is Test, SymTest {
 
     /**
      * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
-     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
-     * and consumes a lot of memory, causing the CI to crash due to out of memory.
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly
+     * running and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertMulDiv(
     //     uint256 x,
@@ -113,8 +113,8 @@ contract MathTestHalmos is Test, SymTest {
 
     /**
      * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
-     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
-     * and consumes a lot of memory, causing the CI to crash due to out of memory.
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly
+     * running and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadLn(int256 x) public view {
     //     assertEq(math.wad_ln(x), FixedPointMathLib.lnWad(x));
@@ -122,8 +122,8 @@ contract MathTestHalmos is Test, SymTest {
 
     /**
      * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
-     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
-     * and consumes a lot of memory, causing the CI to crash due to out of memory.
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly
+     * running and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadExp(int256 x) public view {
     //     assertEq(math.wad_exp(x), FixedPointMathLib.expWad(x));
@@ -131,8 +131,8 @@ contract MathTestHalmos is Test, SymTest {
 
     /**
      * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
-     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
-     * and consumes a lot of memory, causing the CI to crash due to out of memory.
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly
+     * running and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertCbrt(uint256 x, bool roundup) public view {
     //     if (!roundup) {
@@ -147,8 +147,8 @@ contract MathTestHalmos is Test, SymTest {
 
     /**
      * @dev Currently commented out, as the timeout for the Yices 2 SMT solver does not
-     * work for the queries of this test, where the Yices 2 SMT solver is constantly running
-     * and consumes a lot of memory, causing the CI to crash due to out of memory.
+     * work for the queries of this test, where the Yices 2 SMT solver is constantly
+     * running and consumes a lot of memory, causing the CI to crash due to out of memory.
      */
     // function testHalmosAssertWadCbrt(uint256 x) public view {
     //     assertEq(math.wad_cbrt(x), FixedPointMathLib.cbrtWad(x));


### PR DESCRIPTION
### 🕓 Changelog

[`halmos`](https://github.com/a16z/halmos) has released support for the following new cheat codes via PRs [#360](https://github.com/a16z/halmos/pull/360) and (small patch) [#364](https://github.com/a16z/halmos/pull/364):

```solidity
createCalldata(string contractName);
createCalldata(string contractName, bool includeViewFunctions);
createCalldata(string filename, string contractName);
createCalldata(string filename, string contractName, bool includeViewFunctions);
```

> Please note that `includeViewFunctions` defaults to `false`, if not provided.

This PR refactors the `halmos`-based tests to capitalise on these new cheat codes. To verify the correct behaviour of the Vyper compiler for `view` and `pure` functions, we include read-only functions in the calldata creation.

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/69e9b5c5-cc31-4051-8b0d-c89ed8379451)