### PR TITLE
♻️ Use `cancun` in `echidna`-Based Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@
 - All 🐍 snekmate contract tests, i.e. unit tests, stateless and stateful fuzzing tests (including Echidna), and Halmos-based symbolic tests, are now also run against the experimental Venom backend. ([#268](https://github.com/pcaversaccio/snekmate/pull/268))
 
 - **Tokens**
-  - [`erc20`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc20.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
-  - [`erc721`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc721.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+  - [`erc20`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc20.vy):
+    - Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+    - Use the EVM version `cancun` in `echidna`-based tests. ([#286](https://github.com/pcaversaccio/snekmate/pull/286))
+  - [`erc721`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc721.vy):
+    - Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
+    - Use the EVM version `cancun` in `echidna`-based tests. ([#286](https://github.com/pcaversaccio/snekmate/pull/286))
   - [`erc1155`](https://github.com/pcaversaccio/snekmate/blob/v0.1.1/src/snekmate/tokens/erc1155.vy): Use native `halmos` `createCalldata` cheat code. ([#273](https://github.com/pcaversaccio/snekmate/pull/273))
 
 ### 👀 Full Changelog

--- a/foundry.toml
+++ b/foundry.toml
@@ -31,7 +31,6 @@ invariant = { runs = 375, depth = 500 }                          # Increase the 
 # Default overrides for the Echidna tests.
 [profile.echidna]
 force = true                                                     # Perform always a clean build.
-evm_version = "shanghai"                                         # Set the EVM target version to `shanghai`.
 
 # Default overrides for the Halmos tests.
 [profile.halmos]
@@ -53,7 +52,6 @@ vyper = { experimental_codegen = true }                          # Enable experi
 # Default overrides for the the Venom-based Echidna tests.
 [profile.echidna-venom]
 force = true                                                     # Perform always a clean build.
-evm_version = "shanghai"                                         # Set the EVM target version to `shanghai`.
 vyper = { experimental_codegen = true }                          # Enable experimental code generation using the Venom backend.
 
 # Default overrides for the Venom-based Halmos tests.

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "CHANGELOG.md"
   ],
   "devDependencies": {
-    "@eslint/js": "^9.12.0",
+    "@eslint/js": "^9.13.0",
     "@openzeppelin/merkle-tree": "^1.0.7",
-    "eslint": "^9.12.0",
+    "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",
     "ethers": "^6.13.4",
     "keccak256": "^1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     devDependencies:
       '@eslint/js':
-        specifier: ^9.12.0
-        version: 9.12.0
+        specifier: ^9.13.0
+        version: 9.13.0
       '@openzeppelin/merkle-tree':
         specifier: ^1.0.7
         version: 1.0.7
       eslint:
-        specifier: ^9.12.0
-        version: 9.12.0
+        specifier: ^9.13.0
+        version: 9.13.0
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.12.0)
+        version: 9.1.0(eslint@9.13.0)
       ethers:
         specifier: ^6.13.4
         version: 6.13.4
@@ -73,24 +73,24 @@ packages:
     resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.6.0':
-    resolution: {integrity: sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==}
+  '@eslint/core@0.7.0':
+    resolution: {integrity: sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.1.0':
     resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.12.0':
-    resolution: {integrity: sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==}
+  '@eslint/js@9.13.0':
+    resolution: {integrity: sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.4':
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.2.0':
-    resolution: {integrity: sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==}
+  '@eslint/plugin-kit@0.2.1':
+    resolution: {integrity: sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ethereumjs/rlp@4.0.1':
@@ -433,8 +433,8 @@ packages:
     resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.12.0:
-    resolution: {integrity: sha512-UVIOlTEWxwIopRL1wgSQYdnVDcEvs2wyaO6DGo5mXqe3r16IoCNWkR29iHhyaP4cICWjbgbmFUGAhh0GJRuGZw==}
+  eslint@9.13.0:
+    resolution: {integrity: sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -987,9 +987,9 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.12.0)':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.13.0)':
     dependencies:
-      eslint: 9.12.0
+      eslint: 9.13.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.11.1': {}
@@ -1002,7 +1002,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/core@0.6.0': {}
+  '@eslint/core@0.7.0': {}
 
   '@eslint/eslintrc@3.1.0':
     dependencies:
@@ -1018,11 +1018,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.12.0': {}
+  '@eslint/js@9.13.0': {}
 
   '@eslint/object-schema@2.1.4': {}
 
-  '@eslint/plugin-kit@0.2.0':
+  '@eslint/plugin-kit@0.2.1':
     dependencies:
       levn: 0.4.1
 
@@ -1397,9 +1397,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@9.1.0(eslint@9.12.0):
+  eslint-config-prettier@9.1.0(eslint@9.13.0):
     dependencies:
-      eslint: 9.12.0
+      eslint: 9.13.0
 
   eslint-scope@8.1.0:
     dependencies:
@@ -1410,15 +1410,15 @@ snapshots:
 
   eslint-visitor-keys@4.1.0: {}
 
-  eslint@9.12.0:
+  eslint@9.13.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@eslint-community/regexpp': 4.11.1
       '@eslint/config-array': 0.18.0
-      '@eslint/core': 0.6.0
+      '@eslint/core': 0.7.0
       '@eslint/eslintrc': 3.1.0
-      '@eslint/js': 9.12.0
-      '@eslint/plugin-kit': 0.2.0
+      '@eslint/js': 9.13.0
+      '@eslint/plugin-kit': 0.2.1
       '@humanfs/node': 0.16.5
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.3.1

--- a/test/tokens/echidna/ERC20Properties.sol
+++ b/test/tokens/echidna/ERC20Properties.sol
@@ -32,18 +32,11 @@ contract CryticERC20ExternalHarness is
             _NAME_EIP712,
             _VERSION_EIP712
         );
-        /**
-         * @dev `hevm` does not currently work with the EVM version `cancun`:
-         * https://github.com/ethereum/hevm/issues/469. For Echidna-based tests,
-         * we therefore use the EVM version `shanghai`.
-         */
         token = ITokenMock(
             vyperDeployer.deployContract(
                 "src/snekmate/tokens/mocks/",
                 "erc20_mock",
-                args,
-                "shanghai",
-                "gas"
+                args
             )
         );
     }

--- a/test/tokens/echidna/ERC721Properties.sol
+++ b/test/tokens/echidna/ERC721Properties.sol
@@ -31,18 +31,11 @@ contract CryticERC721ExternalHarness is
             _NAME_EIP712,
             _VERSION_EIP712
         );
-        /**
-         * @dev `hevm` does not currently work with the EVM version `cancun`:
-         * https://github.com/ethereum/hevm/issues/469. For Echidna-based tests,
-         * we therefore use the EVM version `shanghai`.
-         */
         token = IERC721Internal(
             vyperDeployer.deployContract(
                 "src/snekmate/tokens/mocks/",
                 "erc721_mock",
-                args,
-                "shanghai",
-                "gas"
+                args
             )
         );
         mockSafeReceiver = new MockReceiver(true);


### PR DESCRIPTION
### 🕓 Changelog

This PR updates the 🐍 snekmate's `echidna`-based tests to match the new `cancun` EVM support introduced in `echidna` [`v2.2.5`](https://github.com/crytic/echidna/releases/tag/v2.2.5). This ensures our tests remain compatible with the latest EVM version.

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/b3c3ab83-6809-4e58-8297-36e715f14be4)