### PR TITLE
👷‍♂️ Update Python to Version `3.13`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
         node_version:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,4 +109,4 @@ jobs:
           awesome_bot ./*.md src/snekmate/**/*.vy src/snekmate/**/mocks/*.vy src/snekmate/**/interfaces/*.vyi \
           test/**/*.sol test/**/interfaces/*.sol test/**/mocks/*.sol test/**/scripts/*.js scripts/*.sh lib/utils/*.sol lib/utils/*.py \
           --allow-dupe --allow-redirect --request-delay 0.4 \
-          --white-list https://www.wagmi.xyz,https://github.com/pcaversaccio/snekmate.git@,https://github.com/pcaversaccio/snekmate/releases/tag/v0.1.1,https://github.com/pcaversaccio/snekmate/blob/v0.1.1,https://github.com/pcaversaccio/snekmate/compare/v0.1.0...v0.1.1,https://hyperelliptic.org
+          --white-list https://www.wagmi.xyz,https://github.com/pcaversaccio/snekmate.git@,https://github.com/vyperlang/vyper@,https://github.com/pcaversaccio/snekmate/releases/tag/v0.1.1,https://github.com/pcaversaccio/snekmate/blob/v0.1.1,https://github.com/pcaversaccio/snekmate/compare/v0.1.0...v0.1.1,https://hyperelliptic.org

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,4 +109,4 @@ jobs:
           awesome_bot ./*.md src/snekmate/**/*.vy src/snekmate/**/mocks/*.vy src/snekmate/**/interfaces/*.vyi \
           test/**/*.sol test/**/interfaces/*.sol test/**/mocks/*.sol test/**/scripts/*.js scripts/*.sh lib/utils/*.sol lib/utils/*.py \
           --allow-dupe --allow-redirect --request-delay 0.4 \
-          --white-list https://www.wagmi.xyz,https://github.com/pcaversaccio/snekmate.git@,https://github.com/vyperlang/vyper@,https://github.com/pcaversaccio/snekmate/releases/tag/v0.1.1,https://github.com/pcaversaccio/snekmate/blob/v0.1.1,https://github.com/pcaversaccio/snekmate/compare/v0.1.0...v0.1.1,https://hyperelliptic.org
+          --white-list https://www.wagmi.xyz,https://github.com/pcaversaccio/snekmate.git@,https://github.com/vyperlang/vyper.git@,https://github.com/pcaversaccio/snekmate/releases/tag/v0.1.1,https://github.com/pcaversaccio/snekmate/blob/v0.1.1,https://github.com/pcaversaccio/snekmate/compare/v0.1.0...v0.1.1,https://hyperelliptic.org

--- a/.github/workflows/halmos-venom.yml
+++ b/.github/workflows/halmos-venom.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
         halmos:

--- a/.github/workflows/halmos.yml
+++ b/.github/workflows/halmos.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
         halmos:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
 

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
 

--- a/.github/workflows/test-contracts-venom.yml
+++ b/.github/workflows/test-contracts-venom.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
         node_version:

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
         python_version:
-          - 3.12
+          - 3.13
         architecture:
           - x64
         node_version:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,20 @@ You will need the following dependencies:
 - [Git](https://git-scm.com)
 - [Node.js](https://nodejs.org)
 - [pnpm](https://pnpm.io)
+- [Python](https://www.python.org)
 - [🐍Vyper](https://github.com/vyperlang/vyper)
 - [Foundry](https://github.com/foundry-rs/foundry)
 
 ## ⚙️ Installation
+
+> [!IMPORTANT]
+> All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch of 🐍 Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper@master` (note that Python version `3.10` or higher is required).
+
+```bash
+pip install git+https://github.com/vyperlang/vyper@master
+```
+
+**Note:** Python version **3.10** or higher is required.
 
 It is recommended to install [`pnpm`](https://pnpm.io) through the `npm` package manager, which comes bundled with [Node.js](https://nodejs.org/en) when you install it on your system. It is recommended to use a Node.js version `>= 22.0.0`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,6 @@ You will need the following dependencies:
 > [!IMPORTANT]
 > All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch commit of 🐍Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper@master` (note that Python version `3.10` or higher is required).
 
-```bash
-pip install git+https://github.com/vyperlang/vyper@master
-```
-
-**Note:** Python version **3.10** or higher is required.
-
 It is recommended to install [`pnpm`](https://pnpm.io) through the `npm` package manager, which comes bundled with [Node.js](https://nodejs.org/en) when you install it on your system. It is recommended to use a Node.js version `>= 22.0.0`.
 
 Once you have `npm` installed, you can run the following both to install and upgrade `pnpm`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ You will need the following dependencies:
 ## ⚙️ Installation
 
 > [!IMPORTANT]
-> All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch of 🐍 Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper@master` (note that Python version `3.10` or higher is required).
+> All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch commit of 🐍Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper@master` (note that Python version `3.10` or higher is required).
 
 ```bash
 pip install git+https://github.com/vyperlang/vyper@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ You will need the following dependencies:
 ## ⚙️ Installation
 
 > [!IMPORTANT]
-> All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch commit of 🐍Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper@master` (note that Python version `3.10` or higher is required).
+> All 🐍 snekmate contracts in the `main` branch are designed to work with the latest `master` branch commit of 🐍Vyper, which can be installed via `pip install git+https://github.com/vyperlang/vyper.git@master` (note that Python version `3.10` or higher is required).
 
 It is recommended to install [`pnpm`](https://pnpm.io) through the `npm` package manager, which comes bundled with [Node.js](https://nodejs.org/en) when you install it on your system. It is recommended to use a Node.js version `>= 22.0.0`.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can install 🐍 snekmate from [PyPI](https://pypi.org/project/snekmate) wit
 pip install snekmate
 ```
 
-> When using the 🐍Vyper CLI, the search path [defaults](https://docs.vyperlang.org/en/latest/structure-of-a-contract.html#searching-for-imports) to the current working directory and the Python [`sys.path`](https://docs.python.org/3.12/library/sys.html#sys.path). As a result, all imported 🐍 snekmate contracts (e.g. `from snekmate.tokens import erc20`) are seamlessly located during compilation.
+> When using the 🐍Vyper CLI, the search path [defaults](https://docs.vyperlang.org/en/latest/structure-of-a-contract.html#searching-for-imports) to the current working directory and the Python [`sys.path`](https://docs.python.org/3.13/library/sys.html#sys.path). As a result, all imported 🐍 snekmate contracts (e.g. `from snekmate.tokens import erc20`) are seamlessly located during compilation.
 
 ### 2️⃣ Foundry
 


### PR DESCRIPTION
### 🕓 Changelog

This PR upgrades [Python](https://www.python.org) to the latest [`3.13`](https://docs.python.org/3/whatsnew/3.13.html) release in the CI pipelines. In addition, the contribution guidelines are amended to include Python as a required dependency.

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/0d6a99de-0521-4db9-aeef-9be4eb0ab076 width="1050"/>