### PR TITLE
📖 Fix Broken `erc20`/`erc721` Links in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ This repository contains [Foundry](https://github.com/foundry-rs/foundry)-based 
 
 ✅ Test Type Implemented &emsp; ❌ Test Type Not Implemented
 
-Furthermore, the [`echidna`](https://github.com/crytic/echidna)-based [property](https://github.com/crytic/properties) tests for the [`erc20`](./src/snekmate/tokens/ERC20.vy) and [`erc721`](./src/snekmate/tokens/ERC721.vy) contracts are available in the [`test/tokens/echidna/`](./test/tokens/echidna) directory. You can run the tests by invoking:
+Furthermore, the [`echidna`](https://github.com/crytic/echidna)-based [property](https://github.com/crytic/properties) tests for the [`erc20`](./src/snekmate/tokens/erc20.vy) and [`erc721`](./src/snekmate/tokens/erc721.vy) contracts are available in the [`test/tokens/echidna/`](./test/tokens/echidna) directory. You can run the tests by invoking:
 
 ```console
 # Run Echidna ERC-20 property tests.


### PR DESCRIPTION
### 🕓 Changelog

This PR fixes two broken links in the [`README` test section](https://github.com/pcaversaccio/snekmate?#%EF%B8%8F-tests) that point to `ERC20.vy` and `ERC721.vy` 🐍Vyper contract files. The issue is due to case sensitivity, as the actual repository structure uses lowercase `erc20.vy` and `erc721.vy`.

#### 🐶 Cute Animal Picture

<img src=https://masterpiecer-images.s3.yandex.net/5f99bfc9b98a2dc:upscaled width="1050"/>