### PR TITLE
📖 Document `MODEXP` Requirement in `p256`

### DIFF
--- a/src/snekmate/utils/p256.vy
+++ b/src/snekmate/utils/p256.vy
@@ -12,14 +12,14 @@
         The implementation is inspired by dcposch's and nalinbhardwaj's
         implementation here:
         https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol.
-@custom:security When using these functions, ensure that your underlying
-                 chain supports the precompile for modular exponentiation
-                 at address `0x0000000000000000000000000000000000000005`,
-                 as specified in EIP-198 (https://eips.ethereum.org/EIPS/eip-198;
-                 included as part of the Byzantium hard fork). Otherwise,
+@custom:security When using these functions, ensure that the underlying
+                 chain supports the `MODEXP` precompiled contract at the
+                 address `0x0000000000000000000000000000000000000005`,
+                 as defined in EIP-198 (https://eips.ethereum.org/EIPS/eip-198)
+                 and introduced in the Byzantium hard fork. Otherwise,
                  these functions will revert due to the absence of the
-                 required precompile. For example, ZKsync Era does not
-                 currently support this precompiled contract:
+                 required precompile contract. For example, ZKsync Era
+                 does not currently support this precompiled contract:
                  https://docs.zksync.io/zksync-protocol/differences/pre-compiles.
 """
 

--- a/src/snekmate/utils/p256.vy
+++ b/src/snekmate/utils/p256.vy
@@ -12,6 +12,15 @@
         The implementation is inspired by dcposch's and nalinbhardwaj's
         implementation here:
         https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol.
+@custom:security When using these functions, ensure that your underlying
+                 chain supports the precompile for modular exponentiation
+                 at address `0x0000000000000000000000000000000000000005`,
+                 as specified in EIP-198 (https://eips.ethereum.org/EIPS/eip-198;
+                 included as part of the Byzantium hard fork). Otherwise,
+                 these functions will revert due to the absence of the
+                 required precompile. For example, ZKsync Era does not
+                 currently support this precompiled contract:
+                 https://docs.zksync.io/zksync-protocol/differences/pre-compiles.
 """
 
 

--- a/src/snekmate/utils/p256.vy
+++ b/src/snekmate/utils/p256.vy
@@ -18,7 +18,7 @@
                  as defined in EIP-198 (https://eips.ethereum.org/EIPS/eip-198)
                  and introduced in the Byzantium hard fork. Otherwise,
                  these functions will revert due to the absence of the
-                 required precompile contract. For example, ZKsync Era
+                 required precompiled contract. For example, ZKsync Era
                  does not currently support this precompiled contract:
                  https://docs.zksync.io/zksync-protocol/differences/pre-compiles.
 """


### PR DESCRIPTION
### 🕓 Changelog

This PR documents the requirement for the [`MODEXP`](https://www.evm.codes/precompiled?fork=cancun#0x05) precompiled contract, as specified by [EIP-198](https://eips.ethereum.org/EIPS/eip-198) and introduced in the Byzantium hard fork, for the `p256` contract.

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/263c2796-37e2-43ec-857a-24d149a964c2 width="1050"/>