### PR TITLE
🔁 Update 🐍Vyper Version `pragma` to `v0.4.2rc1`

### DIFF
--- a/lib/utils/VyperDeployer.sol
+++ b/lib/utils/VyperDeployer.sol
@@ -17,14 +17,16 @@ error CompilationFailed(address emitter);
 error DeploymentFailed(address emitter);
 
 /**
- * @dev The interface of this cheat code is called `_CheatCodes`,
- * so you can use the `CheatCodes` interface (see here:
- * https://book.getfoundry.sh/cheatcodes/?highlight=CheatCodes#cheatcode-types)
+ * @dev The interface of this cheat code is called `_VmSafe`, so you
+ * can use the `VmSafe` interface (see here: https://book.getfoundry.sh/cheatcodes)
  * in other test files without errors.
  */
 // solhint-disable-next-line contract-name-capwords
-interface _CheatCodes {
-    function ffi(string[] calldata) external returns (bytes memory);
+interface _VmSafe {
+    /**
+     * @dev Performs a foreign function call via the terminal.
+     */
+    function ffi(string[] calldata commandInput) external returns (bytes memory result);
 }
 
 /**
@@ -42,10 +44,10 @@ contract VyperDeployer is Create {
     address private self = address(this);
 
     /**
-     * @dev Initialises `cheatCodes` in order to use the foreign function interface (ffi)
+     * @dev Initialises `vmSafe` in order to use the foreign function interface (ffi)
      * to compile the Vyper contracts.
      */
-    _CheatCodes private cheatCodes = _CheatCodes(HEVM_ADDRESS);
+    _VmSafe private vmSafe = _VmSafe(HEVM_ADDRESS);
 
     /**
      * @dev Compiles a Vyper contract and returns the address that the contract
@@ -69,7 +71,7 @@ contract VyperDeployer is Create {
         /**
          * @dev Compile the Vyper contract and return the bytecode.
          */
-        bytes memory bytecode = cheatCodes.ffi(cmds);
+        bytes memory bytecode = vmSafe.ffi(cmds);
 
         /**
          * @dev Revert if the Vyper compilation failed or is a zero-length
@@ -124,7 +126,7 @@ contract VyperDeployer is Create {
         /**
          * @dev Compile the Vyper contract and return the bytecode.
          */
-        bytes memory bytecode = cheatCodes.ffi(cmds);
+        bytes memory bytecode = vmSafe.ffi(cmds);
 
         /**
          * @dev Revert if the Vyper compilation failed or is a zero-length
@@ -194,7 +196,7 @@ contract VyperDeployer is Create {
         /**
          * @dev Compile the Vyper contract and return the bytecode.
          */
-        bytes memory bytecode = cheatCodes.ffi(cmds);
+        bytes memory bytecode = vmSafe.ffi(cmds);
 
         /**
          * @dev Revert if the Vyper compilation failed or is a zero-length
@@ -262,7 +264,7 @@ contract VyperDeployer is Create {
         /**
          * @dev Compile the Vyper contract and return the bytecode.
          */
-        bytes memory bytecode = cheatCodes.ffi(cmds);
+        bytes memory bytecode = vmSafe.ffi(cmds);
 
         /**
          * @dev Revert if the Vyper compilation failed or is a zero-length

--- a/lib/utils/compile.py
+++ b/lib/utils/compile.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys, subprocess, json
 
 

--- a/src/snekmate/auth/access_control.vy
+++ b/src/snekmate/auth/access_control.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Multi-Role-Based Access Control Functions

--- a/src/snekmate/auth/interfaces/IAccessControl.vyi
+++ b/src/snekmate/auth/interfaces/IAccessControl.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title `access_control` Interface Definition
 @custom:contract-name IAccessControl

--- a/src/snekmate/auth/mocks/access_control_mock.vy
+++ b/src/snekmate/auth/mocks/access_control_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `access_control` Module Reference Implementation

--- a/src/snekmate/auth/mocks/ownable_2step_mock.vy
+++ b/src/snekmate/auth/mocks/ownable_2step_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `ownable_2step` Module Reference Implementation

--- a/src/snekmate/auth/mocks/ownable_mock.vy
+++ b/src/snekmate/auth/mocks/ownable_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `ownable` Module Reference Implementation

--- a/src/snekmate/auth/ownable.vy
+++ b/src/snekmate/auth/ownable.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Owner-Based Access Control Functions

--- a/src/snekmate/auth/ownable_2step.vy
+++ b/src/snekmate/auth/ownable_2step.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title 2-Step Ownership Transfer Functions

--- a/src/snekmate/extensions/erc2981.vy
+++ b/src/snekmate/extensions/erc2981.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title ERC-721 and ERC-1155 Compatible ERC-2981 Reference Implementation

--- a/src/snekmate/extensions/erc4626.vy
+++ b/src/snekmate/extensions/erc4626.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Modern and Gas-Efficient ERC-4626 Tokenised Vault Implementation

--- a/src/snekmate/extensions/interfaces/IERC2981.vyi
+++ b/src/snekmate/extensions/interfaces/IERC2981.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-2981 Interface Definition
 @custom:contract-name IERC2981

--- a/src/snekmate/extensions/mocks/erc2981_mock.vy
+++ b/src/snekmate/extensions/mocks/erc2981_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `erc2981` Module Reference Implementation

--- a/src/snekmate/extensions/mocks/erc4626_mock.vy
+++ b/src/snekmate/extensions/mocks/erc4626_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `erc4626` Module Reference Implementation

--- a/src/snekmate/governance/mocks/timelock_controller_mock.vy
+++ b/src/snekmate/governance/mocks/timelock_controller_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `timelock_controller` Module Reference Implementation

--- a/src/snekmate/governance/timelock_controller.vy
+++ b/src/snekmate/governance/timelock_controller.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Multi-Role-Based Timelock Controller Reference Implementation

--- a/src/snekmate/tokens/erc1155.vy
+++ b/src/snekmate/tokens/erc1155.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Modern and Gas-Efficient ERC-1155 Implementation

--- a/src/snekmate/tokens/erc20.vy
+++ b/src/snekmate/tokens/erc20.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Modern and Gas-Efficient ERC-20 + EIP-2612 Implementation

--- a/src/snekmate/tokens/erc721.vy
+++ b/src/snekmate/tokens/erc721.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Modern and Gas-Efficient ERC-721 + EIP-4494 Implementation

--- a/src/snekmate/tokens/interfaces/IERC1155.vyi
+++ b/src/snekmate/tokens/interfaces/IERC1155.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-1155 Interface Definition
 @custom:contract-name IERC1155

--- a/src/snekmate/tokens/interfaces/IERC1155MetadataURI.vyi
+++ b/src/snekmate/tokens/interfaces/IERC1155MetadataURI.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-1155 Optional Metadata Interface Definition
 @custom:contract-name IERC1155MetadataURI

--- a/src/snekmate/tokens/interfaces/IERC1155Receiver.vyi
+++ b/src/snekmate/tokens/interfaces/IERC1155Receiver.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-1155 Token Receiver Interface Definition
 @custom:contract-name IERC1155Receiver

--- a/src/snekmate/tokens/interfaces/IERC20Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC20Permit.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-2612 Interface Definition
 @custom:contract-name IERC20Permit

--- a/src/snekmate/tokens/interfaces/IERC4906.vyi
+++ b/src/snekmate/tokens/interfaces/IERC4906.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-4906 Interface Definition
 @custom:contract-name IERC4906

--- a/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-721 Optional Enumeration Interface Definition
 @custom:contract-name IERC721Enumerable

--- a/src/snekmate/tokens/interfaces/IERC721Metadata.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Metadata.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-721 Optional Metadata Interface Definition
 @custom:contract-name IERC721Metadata

--- a/src/snekmate/tokens/interfaces/IERC721Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Permit.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-4494 Interface Definition
 @custom:contract-name IERC721Permit

--- a/src/snekmate/tokens/interfaces/IERC721Receiver.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Receiver.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-721 Token Receiver Interface Definition
 @custom:contract-name IERC721Receiver

--- a/src/snekmate/tokens/mocks/erc1155_mock.vy
+++ b/src/snekmate/tokens/mocks/erc1155_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `erc1155` Module Reference Implementation

--- a/src/snekmate/tokens/mocks/erc20_mock.vy
+++ b/src/snekmate/tokens/mocks/erc20_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `erc20` Module Reference Implementation

--- a/src/snekmate/tokens/mocks/erc721_mock.vy
+++ b/src/snekmate/tokens/mocks/erc721_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `erc721` Module Reference Implementation

--- a/src/snekmate/utils/base64.vy
+++ b/src/snekmate/utils/base64.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Base64 Encoding and Decoding Functions

--- a/src/snekmate/utils/batch_distributor.vy
+++ b/src/snekmate/utils/batch_distributor.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Batch Sending Both Native and ERC-20 Tokens

--- a/src/snekmate/utils/block_hash.vy
+++ b/src/snekmate/utils/block_hash.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Utility Functions to Access Historical Block Hashes

--- a/src/snekmate/utils/create2_address.vy
+++ b/src/snekmate/utils/create2_address.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `CREATE2` EVM Opcode Utility Functions for Address Calculations

--- a/src/snekmate/utils/create_address.vy
+++ b/src/snekmate/utils/create_address.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `CREATE` EVM Opcode Utility Functions for Address Calculations

--- a/src/snekmate/utils/ecdsa.vy
+++ b/src/snekmate/utils/ecdsa.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Elliptic Curve Digital Signature Algorithm (ECDSA) Secp256k1-Based Functions

--- a/src/snekmate/utils/eip712_domain_separator.vy
+++ b/src/snekmate/utils/eip712_domain_separator.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title EIP-712 Domain Separator

--- a/src/snekmate/utils/interfaces/IERC1271.vyi
+++ b/src/snekmate/utils/interfaces/IERC1271.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-1271 Interface Definition
 @custom:contract-name IERC1271

--- a/src/snekmate/utils/interfaces/IERC5267.vyi
+++ b/src/snekmate/utils/interfaces/IERC5267.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 """
 @title EIP-5267 Interface Definition
 @custom:contract-name IERC5267

--- a/src/snekmate/utils/math.vy
+++ b/src/snekmate/utils/math.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Standard Mathematical Utility Functions

--- a/src/snekmate/utils/merkle_proof_verification.vy
+++ b/src/snekmate/utils/merkle_proof_verification.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Merkle Tree Proof Verification Functions

--- a/src/snekmate/utils/message_hash_utils.vy
+++ b/src/snekmate/utils/message_hash_utils.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Signature Message Hash Utility Functions

--- a/src/snekmate/utils/mocks/base64_mock.vy
+++ b/src/snekmate/utils/mocks/base64_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `base64` Module Reference Implementation

--- a/src/snekmate/utils/mocks/batch_distributor_mock.vy
+++ b/src/snekmate/utils/mocks/batch_distributor_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `batch_distributor` Module Reference Implementation

--- a/src/snekmate/utils/mocks/block_hash_mock.vy
+++ b/src/snekmate/utils/mocks/block_hash_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `block_hash` Module Reference Implementation

--- a/src/snekmate/utils/mocks/create2_address_mock.vy
+++ b/src/snekmate/utils/mocks/create2_address_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `create2_address` Module Reference Implementation

--- a/src/snekmate/utils/mocks/create_address_mock.vy
+++ b/src/snekmate/utils/mocks/create_address_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `create_address` Module Reference Implementation

--- a/src/snekmate/utils/mocks/ecdsa_mock.vy
+++ b/src/snekmate/utils/mocks/ecdsa_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `ecdsa` Module Reference Implementation

--- a/src/snekmate/utils/mocks/eip712_domain_separator_mock.vy
+++ b/src/snekmate/utils/mocks/eip712_domain_separator_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `eip712_domain_separator` Module Reference Implementation

--- a/src/snekmate/utils/mocks/math_mock.vy
+++ b/src/snekmate/utils/mocks/math_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `math` Module Reference Implementation

--- a/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
+++ b/src/snekmate/utils/mocks/merkle_proof_verification_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `merkle_proof_verification` Module Reference Implementation

--- a/src/snekmate/utils/mocks/message_hash_utils_mock.vy
+++ b/src/snekmate/utils/mocks/message_hash_utils_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `message_hash_utils` Module Reference Implementation

--- a/src/snekmate/utils/mocks/multicall_mock.vy
+++ b/src/snekmate/utils/mocks/multicall_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `multicall` Module Reference Implementation

--- a/src/snekmate/utils/mocks/p256_mock.vy
+++ b/src/snekmate/utils/mocks/p256_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `p256` Module Reference Implementation

--- a/src/snekmate/utils/mocks/pausable_mock.vy
+++ b/src/snekmate/utils/mocks/pausable_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `pausable` Module Reference Implementation

--- a/src/snekmate/utils/mocks/signature_checker_mock.vy
+++ b/src/snekmate/utils/mocks/signature_checker_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title `signature_checker` Module Reference Implementation

--- a/src/snekmate/utils/multicall.vy
+++ b/src/snekmate/utils/multicall.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Multicall Functions

--- a/src/snekmate/utils/p256.vy
+++ b/src/snekmate/utils/p256.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Elliptic Curve Digital Signature Algorithm (ECDSA) Secp256r1-Based Functions

--- a/src/snekmate/utils/pausable.vy
+++ b/src/snekmate/utils/pausable.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title Pausable Functions

--- a/src/snekmate/utils/signature_checker.vy
+++ b/src/snekmate/utils/signature_checker.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version ~=0.4.2rc1
 # pragma nonreentrancy off
 """
 @title ECDSA and EIP-1271 Signature Verification Functions


### PR DESCRIPTION
### 🕓 Changelog

This PR updates the version `pragma`s in all 🐍Vyper source files to target 🐍Vyper's latest release candidate version [`v0.4.2rc1`](https://github.com/vyperlang/vyper/releases/tag/v0.4.2rc1). Furthermore, the interface name `_CheatCodes` in the `VyperDeployer` utility contract is renamed to `_VmSafe` to better align with Foundry's existing naming convention. Finally, the shebang line `#!/usr/bin/env python` is added to the `compile.py` Python script to enable direct execution in Unix-like environments.

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/352a6750-76ef-41d4-afb3-7e987f60773b width="1050"/>