### PR TITLE
📖 Add Contributor Policy for AI-Assisted Content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If you are looking for an easy starting point, look for issues labelled as [good
 
 If AI assistance was involved in your contribution, **you must clearly state this in the pull request**, along with the extent of its use. For example, note whether it was used only for documentation or also for code generation. If AI was used to draft pull request comments or responses, that must also be disclosed. Minor, trivial completions (like short phrases or single keywords) do not need disclosure.
 
-**Examples:**
+An example disclosure:
 
 > This PR was written primarily by Claude Code.
 


### PR DESCRIPTION
### 🕓 Changelog

This PR adds a section to the 🐍 snekmate contributing documentation explaining how contributors must disclose _any_ use of AI tools. It's meant to keep the process transparent and help maintainers understand _how much_ of each contribution was written by humans versus AI. This PR was inspired by [ghostty-org/ghostty#8289](https://github.com/ghostty-org/ghostty/pull/8289).

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/b62309be-ea2d-48e1-a931-8367c252d9ae width="1050"/>