### PR TITLE
👷‍♂️ Harden `npm` Release Workflow Against Cache Poisoning Risks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -29,3 +31,5 @@ updates:
       github-actions-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     target-branch: "main"
     labels:
       - "dependencies 🔁"
@@ -14,14 +16,14 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     target-branch: "main"
     labels:
       - "dependencies 🔁"
@@ -31,5 +33,3 @@ updates:
       github-actions-dependencies:
         patterns:
           - "*"
-    cooldown:
-      default-days: 7

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,27 +34,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          run_install: false
-
-      - name: Get pnpm cache directory path
-        id: pnpm-cache-dir-path
-        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
-
-      - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node_version }}
-
-      - name: Install pnpm project with a clean slate
-        run: pnpm install --prefer-offline --frozen-lockfile
+          cache: true
+          run_install: |
+            - args: [--prefer-offline, --frozen-lockfile]
 
       - name: Prettier and lint
         run: pnpm lint:check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,6 @@ jobs:
           - 3.14
         architecture:
           - x64
-        node_version:
-          - 26
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          run_install: false
+          cache: false
+          run_install: |
+            - args: [--prefer-offline, --frozen-lockfile]
 
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -41,9 +43,6 @@ jobs:
           package-manager-cache: false
           node-version: ${{ matrix.node_version }}
           registry-url: "https://registry.npmjs.org"
-
-      - name: Install pnpm project with a clean slate
-        run: pnpm install --prefer-offline --frozen-lockfile
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          package-manager-cache: false
           node-version: ${{ matrix.node_version }}
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,21 +35,10 @@ jobs:
         with:
           run_install: false
 
-      - name: Get pnpm cache directory path
-        id: pnpm-cache-dir-path
-        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
-
       - name: Setup .npmrc file to publish to npm
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          package-manager-cache: false
           node-version: ${{ matrix.node_version }}
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/test-contracts-venom.yml
+++ b/.github/workflows/test-contracts-venom.yml
@@ -51,27 +51,14 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          run_install: false
-
-      - name: Get pnpm cache directory path
-        id: pnpm-cache-dir-path
-        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
+          cache: true
+          run_install: |
+            - args: [--prefer-offline, --frozen-lockfile]
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node_version }}
-
-      - name: Install pnpm project with a clean slate
-        run: pnpm install --prefer-offline --frozen-lockfile
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -62,27 +62,14 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          run_install: false
-
-      - name: Get pnpm cache directory path
-        id: pnpm-cache-dir-path
-        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
+          cache: true
+          run_install: |
+            - args: [--prefer-offline, --frozen-lockfile]
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node_version }}
-
-      - name: Install pnpm project with a clean slate
-        run: pnpm install --prefer-offline --frozen-lockfile
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 ### 🔒 Security Fixes
 
 - Harden GitHub Actions workflows. ([#388](https://github.com/pcaversaccio/snekmate/pull/388))
-- Harden `npm` release workflow against cache poisoning risks. ([#390](https://github.com/pcaversaccio/snekmate/pull/390))
 
 ### 🐛 Bug Fixes
 
@@ -24,6 +23,7 @@
 ### 🔖 Release Management
 
 - Use trusted publishing for `npm` package. ([#341](https://github.com/pcaversaccio/snekmate/pull/341))
+- Harden `npm` release workflow against cache poisoning risks. ([#390](https://github.com/pcaversaccio/snekmate/pull/390))
 
 ### 👀 Full Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🔒 Security Fixes
 
 - Harden GitHub Actions workflows. ([#388](https://github.com/pcaversaccio/snekmate/pull/388))
+- Harden `npm` release workflow against cache poisoning risks. ([#390](https://github.com/pcaversaccio/snekmate/pull/390))
 
 ### 🐛 Bug Fixes
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,6 @@
   ],
   "lockFileMaintenance": {
     "extends": ["group:all"],
-    "commitMessageAction": "Update"
+    "commitMessageAction": "Update `pnpm-lock.yaml`"
   }
 }


### PR DESCRIPTION
### 🕓 Changelog

This PR hardens the release workflow by _disabling_ dependency caching during `npm` publishing to prevent cache poisoning risks, while simplifying the `pnpm` setup across CI workflows and adding a Dependabot cooldown of 7 days.

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/48f7d7bf-bf6c-404f-b58b-7e2eee4c9396 width="1050"/>