### PR TITLE
💥 Migrate `erc20`, `erc721`, and `erc1155` to Custom `error`s

### DIFF
--- a/src/snekmate/auth/ownable.vy
+++ b/src/snekmate/auth/ownable.vy
@@ -31,6 +31,18 @@ event OwnershipTransferred:
     new_owner: indexed(address)
 
 
+# @dev The caller account is not authorized to
+# perform an operation.
+error OwnableUnauthorizedAccount:
+    account: address
+
+
+# @dev The owner is not a valid owner account.
+# (eg. `empty(address)`)
+error OwnableInvalidOwner:
+    owner: address
+
+
 @deploy
 @payable
 def __init__():

--- a/src/snekmate/tokens/erc1155.vy
+++ b/src/snekmate/tokens/erc1155.vy
@@ -52,6 +52,12 @@ from .interfaces import IERC1155MetadataURI
 implements: IERC1155MetadataURI
 
 
+# @dev We import and implement the ERC-6093
+# custom error interface.
+from .interfaces import IERC1155Errors
+implements: IERC1155Errors
+
+
 # @dev We import the `IERC1155Receiver` interface, which
 # is written using standard Vyper syntax.
 from .interfaces import IERC1155Receiver
@@ -140,6 +146,24 @@ event RoleMinterChanged:
     status: bool
 
 
+# @dev The caller is not an authorised minter.
+error ERC1155UnauthorizedMinter:
+    account: address
+
+
+# @dev The minter address is invalid.
+error ERC1155InvalidMinter:
+    minter: address
+
+
+# @dev The token supply is insufficient for the burn.
+error ERC1155InsufficientSupply:
+    sender: address
+    supply: uint256
+    needed: uint256
+    tokenId: uint256
+
+
 @deploy
 @payable
 def __init__(base_uri_: String[80]):
@@ -204,7 +228,7 @@ def safeTransferFrom(owner: address, to: address, id: uint256, amount: uint256, 
     """
     assert (
         owner == msg.sender or self.isApprovedForAll[owner][msg.sender]
-    ), "erc1155: caller is not token owner or approved"
+    ), IERC1155Errors.ERC1155MissingApprovalForAll(operator=msg.sender, owner=owner)
     self._safe_transfer_from(owner, to, id, amount, data)
 
 
@@ -243,7 +267,7 @@ def safeBatchTransferFrom(
     """
     assert (
         owner == msg.sender or self.isApprovedForAll[owner][msg.sender]
-    ), "erc1155: caller is not token owner or approved"
+    ), IERC1155Errors.ERC1155MissingApprovalForAll(operator=msg.sender, owner=owner)
     self._safe_batch_transfer_from(owner, to, ids, amounts, data)
 
 
@@ -261,7 +285,9 @@ def balanceOfBatch(
     @return DynArray The 32-byte array of token amounts
             owned by `owners`.
     """
-    assert len(owners) == len(ids), "erc1155: owners and ids length mismatch"
+    assert len(owners) == len(ids), IERC1155Errors.ERC1155InvalidArrayLength(
+        idsLength=len(ids), valuesLength=len(owners)
+    )
     batch_balances: DynArray[uint256, _BATCH_SIZE] = []
     idx: uint256 = empty(uint256)
     for owner: address in owners:
@@ -320,7 +346,7 @@ def set_uri(id: uint256, token_uri: String[432]):
     @param token_uri The maximum 432-character user-readable
            string URI for computing `uri`.
     """
-    assert self.is_minter[msg.sender], "erc1155: access is denied"
+    assert self.is_minter[msg.sender], ERC1155UnauthorizedMinter(account=msg.sender)
     self._set_uri(id, token_uri)
 
 
@@ -351,7 +377,7 @@ def burn(owner: address, id: uint256, amount: uint256):
     """
     assert (
         owner == msg.sender or self.isApprovedForAll[owner][msg.sender]
-    ), "erc1155: caller is not token owner or approved"
+    ), IERC1155Errors.ERC1155MissingApprovalForAll(operator=msg.sender, owner=owner)
     self._burn(owner, id, amount)
 
 
@@ -371,7 +397,7 @@ def burn_batch(owner: address, ids: DynArray[uint256, _BATCH_SIZE], amounts: Dyn
     """
     assert (
         owner == msg.sender or self.isApprovedForAll[owner][msg.sender]
-    ), "erc1155: caller is not token owner or approved"
+    ), IERC1155Errors.ERC1155MissingApprovalForAll(operator=msg.sender, owner=owner)
     self._burn_batch(owner, ids, amounts)
 
 
@@ -391,7 +417,7 @@ def safe_mint(owner: address, id: uint256, amount: uint256, data: Bytes[1_024]):
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert self.is_minter[msg.sender], "erc1155: access is denied"
+    assert self.is_minter[msg.sender], ERC1155UnauthorizedMinter(account=msg.sender)
     self._safe_mint(owner, id, amount, data)
 
 
@@ -415,7 +441,7 @@ def safe_mint_batch(
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert self.is_minter[msg.sender], "erc1155: access is denied"
+    assert self.is_minter[msg.sender], ERC1155UnauthorizedMinter(account=msg.sender)
     self._safe_mint_batch(owner, ids, amounts, data)
 
 
@@ -432,10 +458,10 @@ def set_minter(minter: address, status: bool):
     @param status The Boolean variable that sets the status.
     """
     ownable._check_owner()
-    assert minter != empty(address), "erc1155: minter is the zero address"
+    assert minter != empty(address), ERC1155InvalidMinter(minter=minter)
     # We ensured in the previous step `ownable._check_owner`
     # that `msg.sender` is the `owner`.
-    assert minter != msg.sender, "erc1155: minter is owner address"
+    assert minter != msg.sender, ERC1155InvalidMinter(minter=minter)
     self.is_minter[minter] = status
     log RoleMinterChanged(minter=minter, status=status)
 
@@ -455,7 +481,7 @@ def transfer_ownership(new_owner: address):
     @param new_owner The 20-byte address of the new owner.
     """
     ownable._check_owner()
-    assert new_owner != empty(address), "erc1155: new owner is the zero address"
+    assert new_owner != empty(address), ownable.OwnableInvalidOwner(owner=new_owner)
 
     self.is_minter[msg.sender] = False
     log RoleMinterChanged(minter=msg.sender, status=False)
@@ -498,7 +524,7 @@ def _set_approval_for_all(owner: address, operator: address, approved: bool):
     @param approved The Boolean variable that sets the
            approval status.
     """
-    assert owner != operator, "erc1155: setting approval status for self"
+    assert owner != operator, IERC1155Errors.ERC1155InvalidOperator(operator=operator)
     self.isApprovedForAll[owner][operator] = approved
     log IERC1155.ApprovalForAll(_owner=owner, _operator=operator, _approved=approved)
 
@@ -529,12 +555,14 @@ def _safe_transfer_from(owner: address, to: address, id: uint256, amount: uint25
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert to != empty(address), "erc1155: transfer to the zero address"
+    assert to != empty(address), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
 
     self._before_token_transfer(owner, to, self._as_singleton_array(id), self._as_singleton_array(amount), data)
 
     owner_balance: uint256 = self.balanceOf[owner][id]
-    assert owner_balance >= amount, "erc1155: insufficient balance for transfer"
+    assert owner_balance >= amount, IERC1155Errors.ERC1155InsufficientBalance(
+        sender=owner, balance=owner_balance, needed=amount, tokenId=id
+    )
     self.balanceOf[owner][id] = unsafe_sub(owner_balance, amount)
     # In the next line, an overflow is not possible
     # due to an arithmetic check of the entire token
@@ -546,7 +574,7 @@ def _safe_transfer_from(owner: address, to: address, id: uint256, amount: uint25
 
     assert self._check_on_erc1155_received(
         owner, to, id, amount, data
-    ), "erc1155: transfer to non-IERC1155Receiver implementer"
+    ), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
 
 
 @internal
@@ -582,8 +610,10 @@ def _safe_batch_transfer_from(
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert len(ids) == len(amounts), "erc1155: ids and amounts length mismatch"
-    assert to != empty(address), "erc1155: transfer to the zero address"
+    assert len(ids) == len(amounts), IERC1155Errors.ERC1155InvalidArrayLength(
+        idsLength=len(ids), valuesLength=len(amounts)
+    )
+    assert to != empty(address), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
 
     self._before_token_transfer(owner, to, ids, amounts, data)
 
@@ -591,7 +621,9 @@ def _safe_batch_transfer_from(
     for id: uint256 in ids:
         amount: uint256 = amounts[idx]
         owner_balance: uint256 = self.balanceOf[owner][id]
-        assert owner_balance >= amount, "erc1155: insufficient balance for transfer"
+        assert owner_balance >= amount, IERC1155Errors.ERC1155InsufficientBalance(
+            sender=owner, balance=owner_balance, needed=amount, tokenId=id
+        )
         self.balanceOf[owner][id] = unsafe_sub(owner_balance, amount)
         # In the next line, an overflow is not possible
         # due to an arithmetic check of the entire token
@@ -609,7 +641,7 @@ def _safe_batch_transfer_from(
 
     assert self._check_on_erc1155_batch_received(
         owner, to, ids, amounts, data
-    ), "erc1155: transfer to non-IERC1155Receiver implementer"
+    ), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
 
 
 @internal
@@ -636,7 +668,7 @@ def _safe_mint(owner: address, id: uint256, amount: uint256, data: Bytes[1_024])
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert owner != empty(address), "erc1155: mint to the zero address"
+    assert owner != empty(address), IERC1155Errors.ERC1155InvalidReceiver(receiver=owner)
 
     self._before_token_transfer(
         empty(address), owner, self._as_singleton_array(id), self._as_singleton_array(amount), data
@@ -654,7 +686,7 @@ def _safe_mint(owner: address, id: uint256, amount: uint256, data: Bytes[1_024])
 
     assert self._check_on_erc1155_received(
         empty(address), owner, id, amount, data
-    ), "erc1155: mint to non-IERC1155Receiver implementer"
+    ), IERC1155Errors.ERC1155InvalidReceiver(receiver=owner)
 
 
 @internal
@@ -685,8 +717,10 @@ def _safe_mint_batch(
     @param data The maximum 1,024-byte additional data
            with no specified format.
     """
-    assert len(ids) == len(amounts), "erc1155: ids and amounts length mismatch"
-    assert owner != empty(address), "erc1155: mint to the zero address"
+    assert len(ids) == len(amounts), IERC1155Errors.ERC1155InvalidArrayLength(
+        idsLength=len(ids), valuesLength=len(amounts)
+    )
+    assert owner != empty(address), IERC1155Errors.ERC1155InvalidReceiver(receiver=owner)
 
     self._before_token_transfer(empty(address), owner, ids, amounts, data)
 
@@ -708,7 +742,7 @@ def _safe_mint_batch(
 
     assert self._check_on_erc1155_batch_received(
         empty(address), owner, ids, amounts, data
-    ), "erc1155: transfer to non-IERC1155Receiver implementer"
+    ), IERC1155Errors.ERC1155InvalidReceiver(receiver=owner)
 
 
 @internal
@@ -780,14 +814,16 @@ def _burn(owner: address, id: uint256, amount: uint256):
     @param id The 32-byte identifier of the token.
     @param amount The 32-byte token amount to be destroyed.
     """
-    assert owner != empty(address), "erc1155: burn from the zero address"
+    assert owner != empty(address), IERC1155Errors.ERC1155InvalidSender(sender=owner)
 
     self._before_token_transfer(
         owner, empty(address), self._as_singleton_array(id), self._as_singleton_array(amount), b""
     )
 
     owner_balance: uint256 = self.balanceOf[owner][id]
-    assert owner_balance >= amount, "erc1155: burn amount exceeds balance"
+    assert owner_balance >= amount, IERC1155Errors.ERC1155InsufficientBalance(
+        sender=owner, balance=owner_balance, needed=amount, tokenId=id
+    )
     self.balanceOf[owner][id] = unsafe_sub(owner_balance, amount)
     log IERC1155.TransferSingle(_operator=msg.sender, _from=owner, _to=empty(address), _id=id, _value=amount)
 
@@ -810,8 +846,10 @@ def _burn_batch(owner: address, ids: DynArray[uint256, _BATCH_SIZE], amounts: Dy
            being destroyed. Note that the order and length must
            match the 32-byte `ids` array.
     """
-    assert len(ids) == len(amounts), "erc1155: ids and amounts length mismatch"
-    assert owner != empty(address), "erc1155: burn from the zero address"
+    assert len(ids) == len(amounts), IERC1155Errors.ERC1155InvalidArrayLength(
+        idsLength=len(ids), valuesLength=len(amounts)
+    )
+    assert owner != empty(address), IERC1155Errors.ERC1155InvalidSender(sender=owner)
 
     self._before_token_transfer(owner, empty(address), ids, amounts, b"")
 
@@ -819,7 +857,9 @@ def _burn_batch(owner: address, ids: DynArray[uint256, _BATCH_SIZE], amounts: Dy
     for id: uint256 in ids:
         amount: uint256 = amounts[idx]
         owner_balance: uint256 = self.balanceOf[owner][id]
-        assert owner_balance >= amount, "erc1155: burn amount exceeds balance"
+        assert owner_balance >= amount, IERC1155Errors.ERC1155InsufficientBalance(
+            sender=owner, balance=owner_balance, needed=amount, tokenId=id
+        )
         self.balanceOf[owner][id] = unsafe_sub(owner_balance, amount)
         # The following line cannot overflow because we have
         # limited the dynamic array `ids` by the `constant`
@@ -854,7 +894,7 @@ def _check_on_erc1155_received(owner: address, to: address, id: uint256, amount:
         return_value: bytes4 = extcall IERC1155Receiver(to).onERC1155Received(msg.sender, owner, id, amount, data)
         assert return_value == method_id(
             "onERC1155Received(address,address,uint256,uint256,bytes)", output_type=bytes4
-        ), "erc1155: transfer to non-IERC1155Receiver implementer"
+        ), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
         return True
 
     # EOA case.
@@ -891,7 +931,7 @@ def _check_on_erc1155_batch_received(
         )
         assert return_value == method_id(
             "onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)", output_type=bytes4
-        ), "erc1155: transfer to non-IERC1155Receiver implementer"
+        ), IERC1155Errors.ERC1155InvalidReceiver(receiver=to)
         return True
 
     # EOA case.
@@ -954,7 +994,9 @@ def _before_token_transfer(
         for id: uint256 in ids:
             amount: uint256 = amounts[idx]
             supply: uint256 = self.total_supply[id]
-            assert supply >= amount, "erc1155: burn amount exceeds total_supply"
+            assert supply >= amount, ERC1155InsufficientSupply(
+                sender=owner, supply=supply, needed=amount, tokenId=id
+            )
             self.total_supply[id] = unsafe_sub(supply, amount)
             # The following line cannot overflow because we have
             # limited the dynamic array `ids` by the `constant`

--- a/src/snekmate/tokens/erc20.vy
+++ b/src/snekmate/tokens/erc20.vy
@@ -64,6 +64,12 @@ from ethereum.ercs import IERC20Detailed
 implements: IERC20Detailed
 
 
+# @dev We import and implement the ERC-6093
+# custom error interface.
+from .interfaces import IERC20Errors
+implements: IERC20Errors
+
+
 # @dev We import and implement the `IERC20Permit`
 # interface, which is written using standard Vyper
 # syntax.
@@ -175,6 +181,16 @@ nonces: public(HashMap[address, uint256])
 event RoleMinterChanged:
     minter: indexed(address)
     status: bool
+
+
+# @dev The caller is not an authorised minter.
+error ERC20UnauthorizedMinter:
+    account: address
+
+
+# @dev The minter address is invalid.
+error ERC20InvalidMinter:
+    minter: address
 
 
 @deploy
@@ -322,7 +338,7 @@ def mint(owner: address, amount: uint256):
     @param owner The 20-byte owner address.
     @param amount The 32-byte token amount to be created.
     """
-    assert self.is_minter[msg.sender], "erc20: access is denied"
+    assert self.is_minter[msg.sender], ERC20UnauthorizedMinter(account=msg.sender)
     self._mint(owner, amount)
 
 
@@ -339,10 +355,10 @@ def set_minter(minter: address, status: bool):
     @param status The Boolean variable that sets the status.
     """
     ownable._check_owner()
-    assert minter != empty(address), "erc20: minter is the zero address"
+    assert minter != empty(address), ERC20InvalidMinter(minter=minter)
     # We ensured in the previous step `ownable._check_owner`
     # that `msg.sender` is the `owner`.
-    assert minter != msg.sender, "erc20: minter is owner address"
+    assert minter != msg.sender, ERC20InvalidMinter(minter=minter)
     self.is_minter[minter] = status
     log RoleMinterChanged(minter=minter, status=status)
 
@@ -369,7 +385,7 @@ def permit(owner: address, spender: address, amount: uint256, deadline: uint256,
     @param r The secp256k1 32-byte signature parameter `r`.
     @param s The secp256k1 32-byte signature parameter `s`.
     """
-    assert block.timestamp <= deadline, "erc20: expired deadline"
+    assert block.timestamp <= deadline, IERC20Permit.ERC2612ExpiredSignature(deadline=deadline)
 
     current_nonce: uint256 = self.nonces[owner]
     self.nonces[owner] = unsafe_add(current_nonce, 1)
@@ -378,7 +394,7 @@ def permit(owner: address, spender: address, amount: uint256, deadline: uint256,
     hash: bytes32 = eip712_domain_separator._hash_typed_data_v4(struct_hash)
 
     signer: address = ecdsa._recover_vrs(hash, convert(v, uint256), convert(r, uint256), convert(s, uint256))
-    assert signer == owner, "erc20: invalid signature"
+    assert signer == owner, IERC20Permit.ERC2612InvalidSigner(signer=signer, owner=owner)
 
     self._approve(owner, spender, amount)
 
@@ -408,7 +424,7 @@ def transfer_ownership(new_owner: address):
     @param new_owner The 20-byte address of the new owner.
     """
     ownable._check_owner()
-    assert new_owner != empty(address), "erc20: new owner is the zero address"
+    assert new_owner != empty(address), ownable.OwnableInvalidOwner(owner=new_owner)
 
     self.is_minter[msg.sender] = False
     log RoleMinterChanged(minter=msg.sender, status=False)
@@ -453,13 +469,15 @@ def _transfer(owner: address, to: address, amount: uint256):
     @param to The 20-byte receiver address.
     @param amount The 32-byte token amount to be transferred.
     """
-    assert owner != empty(address), "erc20: transfer from the zero address"
-    assert to != empty(address), "erc20: transfer to the zero address"
+    assert owner != empty(address), IERC20Errors.ERC20InvalidSender(sender=owner)
+    assert to != empty(address), IERC20Errors.ERC20InvalidReceiver(receiver=to)
 
     self._before_token_transfer(owner, to, amount)
 
     owner_balanceOf: uint256 = self.balanceOf[owner]
-    assert owner_balanceOf >= amount, "erc20: transfer amount exceeds balance"
+    assert owner_balanceOf >= amount, IERC20Errors.ERC20InsufficientBalance(
+        sender=owner, balance=owner_balanceOf, needed=amount
+    )
     self.balanceOf[owner] = unsafe_sub(owner_balanceOf, amount)
     self.balanceOf[to] = unsafe_add(self.balanceOf[to], amount)
     log IERC20.Transfer(sender=owner, receiver=to, value=amount)
@@ -479,7 +497,7 @@ def _mint(owner: address, amount: uint256):
     @param owner The 20-byte owner address.
     @param amount The 32-byte token amount to be created.
     """
-    assert owner != empty(address), "erc20: mint to the zero address"
+    assert owner != empty(address), IERC20Errors.ERC20InvalidReceiver(receiver=owner)
 
     self._before_token_transfer(empty(address), owner, amount)
 
@@ -501,12 +519,14 @@ def _burn(owner: address, amount: uint256):
     @param owner The 20-byte owner address.
     @param amount The 32-byte token amount to be destroyed.
     """
-    assert owner != empty(address), "erc20: burn from the zero address"
+    assert owner != empty(address), IERC20Errors.ERC20InvalidSender(sender=owner)
 
     self._before_token_transfer(owner, empty(address), amount)
 
     account_balance: uint256 = self.balanceOf[owner]
-    assert account_balance >= amount, "erc20: burn amount exceeds balance"
+    assert account_balance >= amount, IERC20Errors.ERC20InsufficientBalance(
+        sender=owner, balance=account_balance, needed=amount
+    )
     self.balanceOf[owner] = unsafe_sub(account_balance, amount)
     self.totalSupply = unsafe_sub(self.totalSupply, amount)
     log IERC20.Transfer(sender=owner, receiver=empty(address), value=amount)
@@ -526,8 +546,8 @@ def _approve(owner: address, spender: address, amount: uint256):
     @param amount The 32-byte token amount that is
            allowed to be spent by the `spender`.
     """
-    assert owner != empty(address), "erc20: approve from the zero address"
-    assert spender != empty(address), "erc20: approve to the zero address"
+    assert owner != empty(address), IERC20Errors.ERC20InvalidApprover(approver=owner)
+    assert spender != empty(address), IERC20Errors.ERC20InvalidSpender(spender=spender)
 
     self.allowance[owner][spender] = amount
     log IERC20.Approval(owner=owner, spender=spender, value=amount)
@@ -555,7 +575,9 @@ def _spend_allowance(owner: address, spender: address, amount: uint256):
         # of `0`. However, this poisoning attack is not an on-chain
         # vulnerability. All assets are safe. It is an off-chain
         # log interpretation issue.
-        assert current_allowance >= amount, "erc20: insufficient allowance"
+        assert current_allowance >= amount, IERC20Errors.ERC20InsufficientAllowance(
+            spender=spender, allowance=current_allowance, needed=amount
+        )
         self._approve(owner, spender, unsafe_sub(current_allowance, amount))
 
 

--- a/src/snekmate/tokens/erc721.vy
+++ b/src/snekmate/tokens/erc721.vy
@@ -59,6 +59,12 @@ from ethereum.ercs import IERC721
 implements: IERC721
 
 
+# @dev We import and implement the ERC-6093
+# custom error interface.
+from .interfaces import IERC721Errors
+implements: IERC721Errors
+
+
 # @dev We import and implement the `IERC721Metadata`
 # interface, which is written using standard Vyper
 # syntax.
@@ -246,6 +252,16 @@ event RoleMinterChanged:
     status: bool
 
 
+# @dev The caller is not an authorised minter.
+error ERC721UnauthorizedMinter:
+    account: address
+
+
+# @dev The minter address is invalid.
+error ERC721InvalidMinter:
+    minter: address
+
+
 @deploy
 @payable
 def __init__(
@@ -345,10 +361,10 @@ def approve(to: address, token_id: uint256):
     @param token_id The 32-byte identifier of the token.
     """
     owner: address = self._owner_of(token_id)
-    assert to != owner, "erc721: approval to current owner"
+    assert to != owner, IERC721Errors.ERC721InvalidOperator(operator=to)
     assert (
         msg.sender == owner or self.isApprovedForAll[owner][msg.sender]
-    ), "erc721: approve caller is not token owner or approved for all"
+    ), IERC721Errors.ERC721InvalidApprover(approver=msg.sender)
     self._approve(to, token_id)
 
 
@@ -406,7 +422,9 @@ def transferFrom(owner: address, to: address, token_id: uint256):
     @param to The 20-byte receiver address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._transfer(owner, to, token_id)
 
 
@@ -453,7 +471,9 @@ def safeTransferFrom(owner: address, to: address, token_id: uint256, data: Bytes
            with no specified format that is sent
            to `to`.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._safe_transfer(owner, to, token_id, data)
 
 
@@ -510,7 +530,9 @@ def tokenByIndex(index: uint256) -> uint256:
     @return uint256 The 32-byte token ID at index
             `index`.
     """
-    assert index < self._total_supply(), "erc721: global index out of bounds"
+    assert index < self._total_supply(), IERC721Enumerable.ERC721OutOfBoundsIndex(
+        owner=empty(address), index=index
+    )
     return self._all_tokens[index]
 
 
@@ -528,7 +550,9 @@ def tokenOfOwnerByIndex(owner: address, index: uint256) -> uint256:
     @return uint256 The 32-byte token ID owned by
             `owner` at index `index`.
     """
-    assert index < self._balance_of(owner), "erc721: owner index out of bounds"
+    assert index < self._balance_of(owner), IERC721Enumerable.ERC721OutOfBoundsIndex(
+        owner=owner, index=index
+    )
     return self._owned_tokens[owner][index]
 
 
@@ -540,7 +564,9 @@ def burn(token_id: uint256):
             or be an approved operator.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._burn(token_id)
 
 
@@ -556,7 +582,7 @@ def safe_mint(owner: address, uri: String[432]):
     @param uri The maximum 432-character user-readable
            string URI for computing `tokenURI`.
     """
-    assert self.is_minter[msg.sender], "erc721: access is denied"
+    assert self.is_minter[msg.sender], ERC721UnauthorizedMinter(account=msg.sender)
     # New tokens will be automatically assigned an incremental ID.
     # The first token ID will be zero.
     token_id: uint256 = self._counter
@@ -584,10 +610,10 @@ def set_minter(minter: address, status: bool):
     @param status The Boolean variable that sets the status.
     """
     ownable._check_owner()
-    assert minter != empty(address), "erc721: minter is the zero address"
+    assert minter != empty(address), ERC721InvalidMinter(minter=minter)
     # We ensured in the previous step `ownable._check_owner`
     # that `msg.sender` is the `owner`.
-    assert minter != msg.sender, "erc721: minter is owner address"
+    assert minter != msg.sender, ERC721InvalidMinter(minter=minter)
     self.is_minter[minter] = status
     log RoleMinterChanged(minter=minter, status=status)
 
@@ -612,7 +638,7 @@ def permit(spender: address, token_id: uint256, deadline: uint256, v: uint8, r: 
     @param r The secp256k1 32-byte signature parameter `r`.
     @param s The secp256k1 32-byte signature parameter `s`.
     """
-    assert block.timestamp <= deadline, "erc721: expired deadline"
+    assert block.timestamp <= deadline, IERC721Permit.ERC4494ExpiredSignature(deadline=deadline)
 
     current_nonce: uint256 = self.nonces[token_id]
     self.nonces[token_id] = unsafe_add(current_nonce, 1)
@@ -621,7 +647,9 @@ def permit(spender: address, token_id: uint256, deadline: uint256, v: uint8, r: 
     hash: bytes32 = eip712_domain_separator._hash_typed_data_v4(struct_hash)
 
     signer: address = ecdsa._recover_vrs(hash, convert(v, uint256), convert(r, uint256), convert(s, uint256))
-    assert signer == self._owner_of(token_id), "erc721: invalid signature"
+    assert signer == self._owner_of(token_id), IERC721Permit.ERC4494InvalidSigner(
+        signer=signer, owner=self._owner_of(token_id)
+    )
 
     self._approve(spender, token_id)
 
@@ -651,7 +679,7 @@ def transfer_ownership(new_owner: address):
     @param new_owner The 20-byte address of the new owner.
     """
     ownable._check_owner()
-    assert new_owner != empty(address), "erc721: new owner is the zero address"
+    assert new_owner != empty(address), ownable.OwnableInvalidOwner(owner=new_owner)
 
     self.is_minter[msg.sender] = False
     log RoleMinterChanged(minter=msg.sender, status=False)
@@ -695,7 +723,7 @@ def _balance_of(owner: address) -> uint256:
     @return uint256 The 32-byte token amount owned
             by `owner`.
     """
-    assert owner != empty(address), "erc721: the zero address is not a valid owner"
+    assert owner != empty(address), IERC721Errors.ERC721InvalidOwner(owner=owner)
     return self._balances[owner]
 
 
@@ -710,7 +738,7 @@ def _owner_of(token_id: uint256) -> address:
     @return address The 20-byte owner address.
     """
     owner: address = self._owners[token_id]
-    assert owner != empty(address), "erc721: invalid token ID"
+    assert owner != empty(address), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
     return owner
 
 
@@ -721,7 +749,7 @@ def _require_minted(token_id: uint256):
     @dev Reverts if the `token_id` has not yet been minted.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._exists(token_id), "erc721: invalid token ID"
+    assert self._exists(token_id), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
 
 
 @internal
@@ -774,7 +802,7 @@ def _set_approval_for_all(owner: address, operator: address, approved: bool):
     @param approved The Boolean variable that sets the
            approval status.
     """
-    assert owner != operator, "erc721: approve to caller"
+    assert owner != operator, IERC721Errors.ERC721InvalidOperator(operator=operator)
     self.isApprovedForAll[owner][operator] = approved
     log IERC721.ApprovalForAll(owner=owner, operator=operator, approved=approved)
 
@@ -817,7 +845,7 @@ def _safe_mint(owner: address, token_id: uint256, data: Bytes[1_024]):
     self._mint(owner, token_id)
     assert self._check_on_erc721_received(
         empty(address), owner, token_id, data
-    ), "erc721: transfer to non-IERC721Receiver implementer"
+    ), IERC721Errors.ERC721InvalidReceiver(receiver=owner)
 
 
 @internal
@@ -832,13 +860,13 @@ def _mint(owner: address, token_id: uint256):
     @param owner The 20-byte owner address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert owner != empty(address), "erc721: mint to the zero address"
-    assert not self._exists(token_id), "erc721: token already minted"
+    assert owner != empty(address), IERC721Errors.ERC721InvalidReceiver(receiver=owner)
+    assert not self._exists(token_id), IERC721Errors.ERC721InvalidSender(sender=empty(address))
 
     self._before_token_transfer(empty(address), owner, token_id)
     # Checks that the `token_id` was not minted by the
     # `_before_token_transfer` hook.
-    assert not self._exists(token_id), "erc721: token already minted"
+    assert not self._exists(token_id), IERC721Errors.ERC721InvalidSender(sender=empty(address))
 
     # Theoretically, the following line could overflow
     # if all 2**256 token IDs were minted to the same owner.
@@ -887,7 +915,7 @@ def _safe_transfer(owner: address, to: address, token_id: uint256, data: Bytes[1
     self._transfer(owner, to, token_id)
     assert self._check_on_erc721_received(
         owner, to, token_id, data
-    ), "erc721: transfer to non-IERC721Receiver implementer"
+    ), IERC721Errors.ERC721InvalidReceiver(receiver=to)
 
 
 @internal
@@ -903,13 +931,19 @@ def _transfer(owner: address, to: address, token_id: uint256):
     @param to The 20-byte receiver address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._owner_of(token_id) == owner, "erc721: transfer from incorrect owner"
-    assert to != empty(address), "erc721: transfer to the zero address"
+    current_owner: address = self._owner_of(token_id)
+    assert current_owner == owner, IERC721Errors.ERC721IncorrectOwner(
+        sender=owner, tokenId=token_id, owner=current_owner
+    )
+    assert to != empty(address), IERC721Errors.ERC721InvalidReceiver(receiver=to)
 
     self._before_token_transfer(owner, to, token_id)
     # Checks that the `token_id` was not transferred by the
     # `_before_token_transfer` hook.
-    assert self._owner_of(token_id) == owner, "erc721: transfer from incorrect owner"
+    current_owner = self._owner_of(token_id)
+    assert current_owner == owner, IERC721Errors.ERC721IncorrectOwner(
+        sender=owner, tokenId=token_id, owner=current_owner
+    )
 
     self._token_approvals[token_id] = empty(address)
     # See comment why an overflow is not possible in the
@@ -931,7 +965,7 @@ def _set_token_uri(token_id: uint256, token_uri: String[432]):
     @param token_uri The maximum 432-character user-readable
            string URI for computing `tokenURI`.
     """
-    assert self._exists(token_id), "erc721: URI set of nonexistent token"
+    assert self._exists(token_id), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
     self._token_uris[token_id] = token_uri
     log IERC4906.MetadataUpdate(_tokenId=token_id)
 
@@ -1000,7 +1034,7 @@ def _check_on_erc721_received(owner: address, to: address, token_id: uint256, da
         return_value: bytes4 = extcall IERC721Receiver(to).onERC721Received(msg.sender, owner, token_id, data)
         assert return_value == method_id(
             "onERC721Received(address,address,uint256,bytes)", output_type=bytes4
-        ), "erc721: transfer to non-IERC721Receiver implementer"
+        ), IERC721Errors.ERC721InvalidReceiver(receiver=to)
         return True
 
     # EOA case.

--- a/src/snekmate/tokens/interfaces/IERC1155Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC1155Errors.vyi
@@ -1,0 +1,49 @@
+# pragma version ~=0.5.0a4
+"""
+@title ERC-1155 Custom Error Interface Definition
+@custom:contract-name IERC1155Errors
+@license GNU Affero General Public License v3.0 only
+@author pcaversaccio
+@notice The custom errors defined by ERC-6093 for
+        ERC-1155 tokens.
+"""
+
+
+# @dev The `sender` does not have enough tokens.
+error ERC1155InsufficientBalance:
+    sender: address
+    balance: uint256
+    needed: uint256
+    tokenId: uint256
+
+
+# @dev The `sender` is not a valid token sender.
+error ERC1155InvalidSender:
+    sender: address
+
+
+# @dev The `receiver` is not a valid token receiver.
+error ERC1155InvalidReceiver:
+    receiver: address
+
+
+# @dev The `operator` is missing approval for all tokens.
+error ERC1155MissingApprovalForAll:
+    operator: address
+    owner: address
+
+
+# @dev The `approver` is not a valid token approver.
+error ERC1155InvalidApprover:
+    approver: address
+
+
+# @dev The `operator` is not a valid token operator.
+error ERC1155InvalidOperator:
+    operator: address
+
+
+# @dev The token ID and amount arrays have different lengths.
+error ERC1155InvalidArrayLength:
+    idsLength: uint256
+    valuesLength: uint256

--- a/src/snekmate/tokens/interfaces/IERC1155Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC1155Errors.vyi
@@ -3,7 +3,7 @@
 @title ERC-1155 Custom Error Interface Definition
 @custom:contract-name IERC1155Errors
 @license GNU Affero General Public License v3.0 only
-@author pcaversaccio
+@author rafael-abuawad
 @notice The custom errors defined by ERC-6093 for
         ERC-1155 tokens.
 """

--- a/src/snekmate/tokens/interfaces/IERC20Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC20Errors.vyi
@@ -1,0 +1,43 @@
+# pragma version ~=0.5.0a4
+"""
+@title ERC-20 Custom Error Interface Definition
+@custom:contract-name IERC20Errors
+@license GNU Affero General Public License v3.0 only
+@author pcaversaccio
+@notice The custom errors defined by ERC-6093 for
+        ERC-20 tokens.
+"""
+
+
+# @dev The `sender` does not have enough tokens.
+error ERC20InsufficientBalance:
+    sender: address
+    balance: uint256
+    needed: uint256
+
+
+# @dev The `sender` is not a valid token sender.
+error ERC20InvalidSender:
+    sender: address
+
+
+# @dev The `receiver` is not a valid token receiver.
+error ERC20InvalidReceiver:
+    receiver: address
+
+
+# @dev The `spender` does not have enough allowance.
+error ERC20InsufficientAllowance:
+    spender: address
+    allowance: uint256
+    needed: uint256
+
+
+# @dev The `approver` is not a valid token approver.
+error ERC20InvalidApprover:
+    approver: address
+
+
+# @dev The `spender` is not a valid token spender.
+error ERC20InvalidSpender:
+    spender: address

--- a/src/snekmate/tokens/interfaces/IERC20Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC20Errors.vyi
@@ -3,7 +3,7 @@
 @title ERC-20 Custom Error Interface Definition
 @custom:contract-name IERC20Errors
 @license GNU Affero General Public License v3.0 only
-@author pcaversaccio
+@author rafael-abuawad
 @notice The custom errors defined by ERC-6093 for
         ERC-20 tokens.
 """

--- a/src/snekmate/tokens/interfaces/IERC20Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC20Permit.vyi
@@ -21,6 +21,17 @@
 """
 
 
+# @dev The permit deadline has expired.
+error ERC2612ExpiredSignature:
+    deadline: uint256
+
+
+# @dev The permit signature does not match the owner.
+error ERC2612InvalidSigner:
+    signer: address
+    owner: address
+
+
 @external
 def permit(owner: address, spender: address, amount: uint256, deadline: uint256, v: uint8, r: bytes32, s: bytes32):
     """

--- a/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
@@ -33,6 +33,13 @@ implements: IERC165
 from ethereum.ercs import IERC721
 
 
+# @dev The requested index is outside the token collection
+# or owner's token list.
+error ERC721OutOfBoundsIndex:
+    owner: address
+    index: uint256
+
+
 @external
 @view
 def supportsInterface(interfaceId: bytes4) -> bool:

--- a/src/snekmate/tokens/interfaces/IERC721Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Errors.vyi
@@ -1,0 +1,52 @@
+# pragma version ~=0.5.0a4
+"""
+@title ERC-721 Custom Error Interface Definition
+@custom:contract-name IERC721Errors
+@license GNU Affero General Public License v3.0 only
+@author pcaversaccio
+@notice The custom errors defined by ERC-6093 for
+        ERC-721 tokens.
+"""
+
+
+# @dev The `owner` is not a valid token owner.
+error ERC721InvalidOwner:
+    owner: address
+
+
+# @dev The `tokenId` does not identify an existing token.
+error ERC721NonexistentToken:
+    tokenId: uint256
+
+
+# @dev The `sender` is not a valid token sender.
+error ERC721InvalidSender:
+    sender: address
+
+
+# @dev The `receiver` is not a valid token receiver.
+error ERC721InvalidReceiver:
+    receiver: address
+
+
+# @dev The transfer is from an incorrect owner.
+error ERC721IncorrectOwner:
+    sender: address
+    tokenId: uint256
+    owner: address
+
+
+# @dev The `operator` is not approved for the token.
+error ERC721InsufficientApproval:
+    operator: address
+    tokenId: uint256
+
+
+# @dev The `approver` is not a valid token approver.
+error ERC721InvalidApprover:
+    approver: address
+
+
+# @dev The `operator` is not a valid token operator.
+error ERC721InvalidOperator:
+    operator: address

--- a/src/snekmate/tokens/interfaces/IERC721Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Errors.vyi
@@ -3,7 +3,7 @@
 @title ERC-721 Custom Error Interface Definition
 @custom:contract-name IERC721Errors
 @license GNU Affero General Public License v3.0 only
-@author pcaversaccio
+@author rafael-abuawad
 @notice The custom errors defined by ERC-6093 for
         ERC-721 tokens.
 """

--- a/src/snekmate/tokens/interfaces/IERC721Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Permit.vyi
@@ -34,6 +34,17 @@ from ethereum.ercs import IERC165
 implements: IERC165
 
 
+# @dev The permit deadline has expired.
+error ERC4494ExpiredSignature:
+    deadline: uint256
+
+
+# @dev The permit signature does not match the owner.
+error ERC4494InvalidSigner:
+    signer: address
+    owner: address
+
+
 @external
 @view
 def supportsInterface(interfaceId: bytes4) -> bool:

--- a/src/snekmate/tokens/mocks/erc1155_mock.vy
+++ b/src/snekmate/tokens/mocks/erc1155_mock.vy
@@ -107,7 +107,7 @@ def _customMint(owner: address, id: uint256, amount: uint256):
     @param id The 32-byte identifier of the token.
     @param amount The 32-byte token amount to be created.
     """
-    assert owner != empty(address), "ERC1155Mock: mint to the zero address"
+    assert owner != empty(address), erc1155.IERC1155Errors.ERC1155InvalidReceiver(receiver=owner)
 
     erc1155._before_token_transfer(
         empty(address), owner, erc1155._as_singleton_array(id), erc1155._as_singleton_array(amount), b""

--- a/test/auth/interfaces/IOwnable.sol
+++ b/test/auth/interfaces/IOwnable.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.36;
 interface IOwnable {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    error OwnableUnauthorizedAccount(address account);
+    error OwnableInvalidOwner(address owner);
+
     function owner() external view returns (address);
 
     function transfer_ownership(address newOwner) external;

--- a/test/extensions/ERC4626.t.sol
+++ b/test/extensions/ERC4626.t.sol
@@ -873,8 +873,16 @@ contract ERC4626VaultTest is ERC4626Test {
         underlying.mint(self, type(uint8).max);
         underlying.approve(ERC4626ExtendedDecimalsOffset0Addr, type(uint8).max);
         ERC4626ExtendedDecimalsOffset0.deposit(type(uint8).max, self);
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
-        vm.prank(makeAddr("otherAccount"));
+        address otherAccount = makeAddr("otherAccount");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientAllowance.selector,
+                otherAccount,
+                0,
+                type(uint8).max
+            )
+        );
+        vm.prank(otherAccount);
         ERC4626ExtendedDecimalsOffset0.withdraw(type(uint8).max, self, self);
     }
 
@@ -1069,7 +1077,7 @@ contract ERC4626VaultTest is ERC4626Test {
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval(owner, spender, amount);
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -1090,7 +1098,7 @@ contract ERC4626VaultTest is ERC4626Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -1119,7 +1127,7 @@ contract ERC4626VaultTest is ERC4626Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -1140,7 +1148,7 @@ contract ERC4626VaultTest is ERC4626Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -1161,7 +1169,9 @@ contract ERC4626VaultTest is ERC4626Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: expired deadline"));
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC4626Extended.ERC2612ExpiredSignature.selector, deadline)
+        );
         ERC4626ExtendedDecimalsOffset0.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -1250,7 +1260,7 @@ contract ERC4626VaultTest is ERC4626Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(ownerAddr, spenderAddr, amount, deadline, v, r, s);
         ERC4626ExtendedDecimalsOffset0.permit(ownerAddr, spenderAddr, amount, deadline, v, r, s);
     }
 
@@ -1297,6 +1307,36 @@ contract ERC4626VaultTest is ERC4626Test {
             abi.encode(_TYPE_HASH, keccak256(bytes(name)), keccak256(bytes(version)), chainId, verifyingContract)
         );
         assertEq(ERC4626ExtendedDecimalsOffset0.DOMAIN_SEPARATOR(), digest);
+    }
+
+    function _expectInvalidSigner(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) private {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                hex"19_01",
+                ERC4626ExtendedDecimalsOffset0.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        _PERMIT_TYPE_HASH,
+                        owner,
+                        spender,
+                        amount,
+                        ERC4626ExtendedDecimalsOffset0.nonces(owner),
+                        deadline
+                    )
+                )
+            )
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC4626Extended.ERC2612InvalidSigner.selector, ecrecover(digest, v, r, s), owner)
+        );
     }
 }
 

--- a/test/extensions/interfaces/IERC4626Extended.sol
+++ b/test/extensions/interfaces/IERC4626Extended.sol
@@ -7,4 +7,7 @@ import {IERC4626} from "openzeppelin/interfaces/IERC4626.sol";
 import {IERC5267} from "openzeppelin/interfaces/IERC5267.sol";
 
 // solhint-disable-next-line no-empty-blocks
-interface IERC4626Extended is IERC20Metadata, IERC20Permit, IERC4626, IERC5267 {}
+interface IERC4626Extended is IERC20Metadata, IERC20Permit, IERC4626, IERC5267 {
+    error ERC2612ExpiredSignature(uint256 deadline);
+    error ERC2612InvalidSigner(address signer, address owner);
+}

--- a/test/tokens/ERC1155.t.sol
+++ b/test/tokens/ERC1155.t.sol
@@ -13,6 +13,7 @@ import {Strings} from "openzeppelin/utils/Strings.sol";
 import {ERC1155ReceiverMock} from "./mocks/ERC1155ReceiverMock.sol";
 
 import {IERC1155Extended} from "./interfaces/IERC1155Extended.sol";
+import {IOwnable} from "../auth/interfaces/IOwnable.sol";
 
 contract ERC1155Test is Test {
     string private constant _BASE_URI = "https://www.wagmi.xyz/";
@@ -214,7 +215,7 @@ contract ERC1155Test is Test {
         owners1[0] = makeAddr("firstOwner");
         owners1[1] = makeAddr("secondAddr");
         ids1[0] = 0;
-        vm.expectRevert(bytes("erc1155: owners and ids length mismatch"));
+        _expectInvalidArrayLength(ids1.length, owners1.length);
         ERC1155Extended.balanceOfBatch(owners1, ids1);
 
         address[] memory owners2 = new address[](1);
@@ -222,7 +223,7 @@ contract ERC1155Test is Test {
         owners2[0] = makeAddr("thirdOwner");
         ids2[0] = 0;
         ids2[1] = 1;
-        vm.expectRevert(bytes("erc1155: owners and ids length mismatch"));
+        _expectInvalidArrayLength(ids2.length, owners2.length);
         ERC1155Extended.balanceOfBatch(owners2, ids2);
     }
 
@@ -264,7 +265,7 @@ contract ERC1155Test is Test {
 
     function testSetApprovalForAllToSelf() public {
         address owner = makeAddr("owner");
-        vm.expectRevert(bytes("erc1155: setting approval status for self"));
+        _expectInvalidOperator(owner);
         vm.prank(owner);
         ERC1155Extended.setApprovalForAll(owner, true);
     }
@@ -342,7 +343,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(operator);
-        vm.expectRevert(bytes("erc1155: caller is not token owner or approved"));
+        _expectMissingApproval(operator, owner);
         ERC1155Extended.safeTransferFrom(owner, receiver, id1, amount1, data);
         vm.stopPrank();
     }
@@ -481,7 +482,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safeTransferFrom(owner, receiver, id1, amount1, data);
         vm.stopPrank();
 
@@ -494,7 +495,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(operator);
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safeTransferFrom(owner, receiver, id2, amount2, data);
         vm.stopPrank();
     }
@@ -580,7 +581,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: insufficient balance for transfer"));
+        _expectInsufficientBalance(owner, amount, amount + 1, id);
         ERC1155Extended.safeTransferFrom(owner, makeAddr("to"), id, ++amount, data);
         vm.stopPrank();
     }
@@ -595,7 +596,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC1155Extended.safeTransferFrom(owner, zeroAddress, id, amount, data);
         vm.stopPrank();
     }
@@ -693,7 +694,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(operator);
-        vm.expectRevert(bytes("erc1155: caller is not token owner or approved"));
+        _expectMissingApproval(operator, owner);
         ERC1155Extended.safeBatchTransferFrom(owner, receiver, ids, amounts, data);
         vm.stopPrank();
     }
@@ -809,7 +810,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safeBatchTransferFrom(owner, receiver, ids, amounts, data);
         vm.stopPrank();
     }
@@ -935,7 +936,7 @@ contract ERC1155Test is Test {
 
         vm.startPrank(owner);
         ++amounts[3];
-        vm.expectRevert(bytes("erc1155: insufficient balance for transfer"));
+        _expectInsufficientBalance(owner, 20, amounts[3], ids[3]);
         ERC1155Extended.safeBatchTransferFrom(owner, makeAddr("to"), ids, amounts, data);
         vm.stopPrank();
     }
@@ -965,9 +966,9 @@ contract ERC1155Test is Test {
         amounts2[2] = 20;
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: ids and amounts length mismatch"));
+        _expectInvalidArrayLength(ids1.length, amounts1.length);
         ERC1155Extended.safeBatchTransferFrom(owner, receiver, ids1, amounts1, data);
-        vm.expectRevert(bytes("erc1155: ids and amounts length mismatch"));
+        _expectInvalidArrayLength(ids2.length, amounts2.length);
         ERC1155Extended.safeBatchTransferFrom(owner, receiver, ids2, amounts2, data);
         vm.stopPrank();
     }
@@ -992,7 +993,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC1155Extended.safeBatchTransferFrom(owner, zeroAddress, ids, amounts, data);
         vm.stopPrank();
     }
@@ -1052,7 +1053,7 @@ contract ERC1155Test is Test {
     }
 
     function testSetUriNonMinter() public {
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(makeAddr("nonOwner"));
         vm.prank(makeAddr("nonOwner"));
         ERC1155Extended.set_uri(1, "my_awesome_uri");
     }
@@ -1278,7 +1279,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(operator);
-        vm.expectRevert(bytes("erc1155: caller is not token owner or approved"));
+        _expectMissingApproval(operator, owner);
         ERC1155Extended.burn(owner, id1, burnAmount);
         vm.stopPrank();
     }
@@ -1286,7 +1287,7 @@ contract ERC1155Test is Test {
     function testBurnFromZeroAddress() public {
         address owner = zeroAddress;
         vm.prank(owner);
-        vm.expectRevert(bytes("erc1155: burn from the zero address"));
+        _expectInvalidSender(owner);
         ERC1155Extended.burn(owner, 1, 1);
     }
 
@@ -1301,7 +1302,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(firstOwner);
-        vm.expectRevert(bytes("erc1155: burn amount exceeds balance"));
+        _expectInsufficientBalance(firstOwner, 15, 16, id);
         ERC1155Extended.burn(firstOwner, id, 16);
         vm.stopPrank();
     }
@@ -1309,7 +1310,7 @@ contract ERC1155Test is Test {
     function testBurnNonExistentTokenId() public {
         address firstOwner = makeAddr("firstOwner");
         vm.prank(firstOwner);
-        vm.expectRevert(bytes("erc1155: burn amount exceeds total_supply"));
+        _expectInsufficientSupply(firstOwner, 0, 1, 1);
         ERC1155Extended.burn(firstOwner, 1, 1);
     }
 
@@ -1406,7 +1407,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.startPrank(operator);
-        vm.expectRevert(bytes("erc1155: caller is not token owner or approved"));
+        _expectMissingApproval(operator, owner);
         ERC1155Extended.burn_batch(owner, ids, amounts);
         vm.stopPrank();
     }
@@ -1434,9 +1435,9 @@ contract ERC1155Test is Test {
         amounts2[2] = 20;
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc1155: ids and amounts length mismatch"));
+        _expectInvalidArrayLength(ids1.length, amounts1.length);
         ERC1155Extended.burn_batch(owner, ids1, amounts1);
-        vm.expectRevert(bytes("erc1155: ids and amounts length mismatch"));
+        _expectInvalidArrayLength(ids2.length, amounts2.length);
         ERC1155Extended.burn_batch(owner, ids2, amounts2);
         vm.stopPrank();
     }
@@ -1456,7 +1457,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.prank(owner);
-        vm.expectRevert(bytes("erc1155: burn from the zero address"));
+        _expectInvalidSender(owner);
         ERC1155Extended.burn_batch(owner, ids, amounts);
     }
 
@@ -1480,7 +1481,7 @@ contract ERC1155Test is Test {
         vm.stopPrank();
 
         vm.startPrank(nonOwner);
-        vm.expectRevert(bytes("erc1155: burn amount exceeds balance"));
+        _expectInsufficientBalance(nonOwner, 0, amounts[0], ids[0]);
         ERC1155Extended.burn_batch(nonOwner, ids, amounts);
         vm.stopPrank();
     }
@@ -1500,7 +1501,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.prank(owner);
-        vm.expectRevert(bytes("erc1155: burn amount exceeds total_supply"));
+        _expectInsufficientSupply(owner, 0, amounts[0], ids[0]);
         ERC1155Extended.burn_batch(owner, ids, amounts);
     }
 
@@ -1602,10 +1603,10 @@ contract ERC1155Test is Test {
         uint256 amount2 = 15;
         bytes memory data = new bytes(0);
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safe_mint(receiver, id1, amount1, data);
 
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safe_mint(receiver, id2, amount2, data);
         vm.stopPrank();
     }
@@ -1657,10 +1658,10 @@ contract ERC1155Test is Test {
         uint256 amount2 = 15;
         bytes memory data = new bytes(0);
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc1155: mint to the zero address"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safe_mint(receiver, id1, amount1, data);
 
-        vm.expectRevert(bytes("erc1155: mint to the zero address"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safe_mint(receiver, id2, amount2, data);
         vm.stopPrank();
     }
@@ -1672,11 +1673,12 @@ contract ERC1155Test is Test {
         uint256 id2 = 4;
         uint256 amount2 = 15;
         bytes memory data = new bytes(0);
-        vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        address nonOwner = makeAddr("nonOwner");
+        vm.startPrank(nonOwner);
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint(receiver, id1, amount1, data);
 
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint(receiver, id2, amount2, data);
         vm.stopPrank();
     }
@@ -1814,7 +1816,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc1155: transfer to non-IERC1155Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC1155Extended.safe_mint_batch(receiver, ids, amounts, data);
         vm.stopPrank();
     }
@@ -1925,10 +1927,10 @@ contract ERC1155Test is Test {
         amounts2[2] = 10;
 
         vm.startPrank(deployer);
-        vm.expectRevert("erc1155: ids and amounts length mismatch");
+        _expectInvalidArrayLength(ids1.length, amounts1.length);
         ERC1155Extended.safe_mint_batch(deployer, ids1, amounts1, data);
 
-        vm.expectRevert("erc1155: ids and amounts length mismatch");
+        _expectInvalidArrayLength(ids2.length, amounts2.length);
         ERC1155Extended.safe_mint_batch(deployer, ids2, amounts2, data);
         vm.stopPrank();
     }
@@ -1948,7 +1950,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc1155: mint to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC1155Extended.safe_mint_batch(zeroAddress, ids, amounts, data);
         vm.stopPrank();
     }
@@ -1967,8 +1969,9 @@ contract ERC1155Test is Test {
         amounts[2] = 10;
         amounts[3] = 20;
 
-        vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        address nonOwner = makeAddr("nonOwner");
+        vm.startPrank(nonOwner);
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint_batch(makeAddr("owner"), ids, amounts, data);
         vm.stopPrank();
     }
@@ -2021,13 +2024,13 @@ contract ERC1155Test is Test {
 
     function testSetMinterToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc1155: minter is the zero address"));
+        _expectInvalidMinter(zeroAddress);
         ERC1155Extended.set_minter(zeroAddress, true);
     }
 
     function testSetMinterRemoveOwnerAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc1155: minter is owner address"));
+        _expectInvalidMinter(deployer);
         ERC1155Extended.set_minter(deployer, false);
     }
 
@@ -2059,7 +2062,7 @@ contract ERC1155Test is Test {
 
     function testTransferOwnershipToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc1155: new owner is the zero address"));
+        _expectInvalidOwner(zeroAddress);
         ERC1155Extended.transfer_ownership(zeroAddress);
     }
 
@@ -2500,7 +2503,7 @@ contract ERC1155Test is Test {
 
     function testFuzzSetUriNonMinter(address nonOwner) public {
         vm.assume(nonOwner != deployer);
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(nonOwner);
         vm.prank(nonOwner);
         ERC1155Extended.set_uri(1, "my_awesome_uri");
     }
@@ -2734,10 +2737,10 @@ contract ERC1155Test is Test {
         uint256 amount2 = 15;
         bytes memory data = new bytes(0);
         vm.startPrank(nonOwner);
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint(receiver, id1, amount1, data);
 
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint(receiver, id2, amount2, data);
         vm.stopPrank();
     }
@@ -2872,7 +2875,7 @@ contract ERC1155Test is Test {
         amounts[3] = 20;
 
         vm.startPrank(nonOwner);
-        vm.expectRevert(bytes("erc1155: access is denied"));
+        _expectUnauthorizedMinter(nonOwner);
         ERC1155Extended.safe_mint_batch(makeAddr("owner"), ids, amounts, data);
         vm.stopPrank();
     }
@@ -2968,6 +2971,56 @@ contract ERC1155Test is Test {
         vm.prank(nonOwner);
         vm.expectRevert(bytes("ownable: caller is not the owner"));
         ERC1155Extended.renounce_ownership();
+    }
+
+    function _expectInvalidArrayLength(uint256 idsLength, uint256 valuesLength) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Extended.ERC1155InvalidArrayLength.selector, idsLength, valuesLength)
+        );
+    }
+
+    function _expectInvalidOperator(address operator) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Extended.ERC1155InvalidOperator.selector, operator));
+    }
+
+    function _expectMissingApproval(address operator, address owner) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Extended.ERC1155MissingApprovalForAll.selector, operator, owner)
+        );
+    }
+
+    function _expectInvalidReceiver(address receiver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Extended.ERC1155InvalidReceiver.selector, receiver));
+    }
+
+    function _expectInsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC1155Extended.ERC1155InsufficientBalance.selector, sender, balance, needed, tokenId
+            )
+        );
+    }
+
+    function _expectInvalidSender(address sender) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Extended.ERC1155InvalidSender.selector, sender));
+    }
+
+    function _expectInsufficientSupply(address sender, uint256 supply, uint256 needed, uint256 tokenId) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Extended.ERC1155InsufficientSupply.selector, sender, supply, needed, tokenId)
+        );
+    }
+
+    function _expectUnauthorizedMinter(address account) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Extended.ERC1155UnauthorizedMinter.selector, account));
+    }
+
+    function _expectInvalidMinter(address minter) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Extended.ERC1155InvalidMinter.selector, minter));
+    }
+
+    function _expectInvalidOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IOwnable.OwnableInvalidOwner.selector, owner));
     }
 }
 

--- a/test/tokens/ERC20.t.sol
+++ b/test/tokens/ERC20.t.sol
@@ -6,6 +6,7 @@ import {VyperDeployer} from "utils/VyperDeployer.sol";
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
+import {IOwnable} from "../auth/interfaces/IOwnable.sol";
 import {IERC20Extended} from "./interfaces/IERC20Extended.sol";
 
 contract ERC20Test is Test {
@@ -106,8 +107,9 @@ contract ERC20Test is Test {
     }
 
     function testTransferInvalidAmount() public {
+        uint256 balance = ERC20Extended.balanceOf(deployer);
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: transfer amount exceeds balance"));
+        _expectInsufficientBalance(deployer, balance, type(uint256).max);
         ERC20Extended.transfer(makeAddr("to"), type(uint256).max);
     }
 
@@ -130,7 +132,7 @@ contract ERC20Test is Test {
         address owner = deployer;
         uint256 amount = ERC20Extended.balanceOf(owner);
         vm.prank(owner);
-        vm.expectRevert(bytes("erc20: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC20Extended.transfer(zeroAddress, amount);
     }
 
@@ -140,7 +142,7 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.burn(amount);
         vm.prank(zeroAddress);
-        vm.expectRevert(bytes("erc20: transfer from the zero address"));
+        _expectInvalidSender(zeroAddress);
         ERC20Extended.transfer(makeAddr("to"), amount);
     }
 
@@ -214,13 +216,13 @@ contract ERC20Test is Test {
         address owner = deployer;
         uint256 amount = ERC20Extended.balanceOf(owner);
         vm.prank(owner);
-        vm.expectRevert(bytes("erc20: approve to the zero address"));
+        _expectInvalidSpender(zeroAddress);
         ERC20Extended.approve(zeroAddress, amount);
     }
 
     function testApproveFromZeroAddress() public {
         vm.prank(zeroAddress);
-        vm.expectRevert(bytes("erc20: approve from the zero address"));
+        _expectInvalidApprover(zeroAddress);
         ERC20Extended.approve(makeAddr("spender"), type(uint256).max);
     }
 
@@ -247,11 +249,12 @@ contract ERC20Test is Test {
     function testTransferFromExceedingBalance() public {
         address owner = deployer;
         address spender = makeAddr("spender");
-        uint256 amount = ERC20Extended.balanceOf(owner) + 1;
+        uint256 balance = ERC20Extended.balanceOf(owner);
+        uint256 amount = balance + 1;
         vm.prank(owner);
         ERC20Extended.approve(spender, amount);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: transfer amount exceeds balance"));
+        _expectInsufficientBalance(owner, balance, amount);
         ERC20Extended.transferFrom(owner, makeAddr("to"), amount);
     }
 
@@ -262,7 +265,7 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.approve(spender, amount - 1);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount - 1, amount);
         ERC20Extended.transferFrom(owner, makeAddr("to"), amount);
     }
 
@@ -273,7 +276,7 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.approve(spender, amount - 1);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount - 1, amount);
         ERC20Extended.transferFrom(owner, makeAddr("to"), amount);
     }
 
@@ -303,13 +306,13 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.approve(spender, amount);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC20Extended.transferFrom(owner, zeroAddress, amount);
     }
 
     function testTransferFromFromZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: approve from the zero address"));
+        _expectInvalidApprover(zeroAddress);
         ERC20Extended.transferFrom(zeroAddress, makeAddr("to"), 0);
     }
 
@@ -346,13 +349,13 @@ contract ERC20Test is Test {
         uint256 balance = ERC20Extended.balanceOf(owner);
         uint256 amount = balance + 1;
         vm.prank(owner);
-        vm.expectRevert(bytes("erc20: burn amount exceeds balance"));
+        _expectInsufficientBalance(owner, balance, amount);
         ERC20Extended.burn(amount);
     }
 
     function testBurnFromZeroAddress() public {
         vm.prank(zeroAddress);
-        vm.expectRevert(bytes("erc20: burn from the zero address"));
+        _expectInvalidSender(zeroAddress);
         ERC20Extended.burn(0);
     }
 
@@ -401,11 +404,12 @@ contract ERC20Test is Test {
     function testBurnFromExceedingBalance() public {
         address owner = deployer;
         address spender = makeAddr("spender");
-        uint256 amount = ERC20Extended.balanceOf(owner) + 1;
+        uint256 balance = ERC20Extended.balanceOf(owner);
+        uint256 amount = balance + 1;
         vm.prank(owner);
         ERC20Extended.approve(spender, amount);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: burn amount exceeds balance"));
+        _expectInsufficientBalance(owner, balance, amount);
         ERC20Extended.burn_from(owner, amount);
     }
 
@@ -416,7 +420,7 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.approve(spender, amount - 1);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount - 1, amount);
         ERC20Extended.burn_from(owner, amount);
     }
 
@@ -427,7 +431,7 @@ contract ERC20Test is Test {
         vm.prank(owner);
         ERC20Extended.approve(spender, amount - 1);
         vm.prank(spender);
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount - 1, amount);
         ERC20Extended.burn_from(owner, amount);
     }
 
@@ -452,7 +456,7 @@ contract ERC20Test is Test {
 
     function testBurnFromFromZeroAddress() public {
         vm.prank(zeroAddress);
-        vm.expectRevert(bytes("erc20: approve to the zero address"));
+        _expectInvalidSpender(zeroAddress);
         ERC20Extended.burn_from(makeAddr("owner"), 0);
     }
 
@@ -471,13 +475,13 @@ contract ERC20Test is Test {
     }
 
     function testMintNonMinter() public {
-        vm.expectRevert(bytes("erc20: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC20Extended.mint(makeAddr("owner"), 100);
     }
 
     function testMintToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: mint to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC20Extended.mint(zeroAddress, 100);
     }
 
@@ -510,13 +514,13 @@ contract ERC20Test is Test {
 
     function testSetMinterToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: minter is the zero address"));
+        _expectInvalidMinter(zeroAddress);
         ERC20Extended.set_minter(zeroAddress, true);
     }
 
     function testSetMinterRemoveOwnerAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: minter is owner address"));
+        _expectInvalidMinter(deployer);
         ERC20Extended.set_minter(deployer, false);
     }
 
@@ -564,7 +568,7 @@ contract ERC20Test is Test {
         vm.expectEmit(true, true, false, true);
         emit IERC20.Approval(owner, spender, amount);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -585,7 +589,7 @@ contract ERC20Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -614,7 +618,7 @@ contract ERC20Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -635,7 +639,7 @@ contract ERC20Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(owner, spender, amount, deadline, v, r, s);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -656,7 +660,7 @@ contract ERC20Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: expired deadline"));
+        _expectExpiredSignature(deadline);
         ERC20Extended.permit(owner, spender, amount, deadline, v, r, s);
     }
 
@@ -730,7 +734,7 @@ contract ERC20Test is Test {
 
     function testTransferOwnershipToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc20: new owner is the zero address"));
+        _expectInvalidOwner(zeroAddress);
         ERC20Extended.transfer_ownership(zeroAddress);
     }
 
@@ -768,8 +772,9 @@ contract ERC20Test is Test {
 
     function testFuzzTransferInvalidAmount(address owner, address to, uint256 amount) public {
         vm.assume(owner != deployer && owner != zeroAddress && to != zeroAddress && amount != 0);
+        uint256 balance = ERC20Extended.balanceOf(owner);
         vm.prank(owner);
-        vm.expectRevert(bytes("erc20: transfer amount exceeds balance"));
+        _expectInsufficientBalance(owner, balance, amount);
         ERC20Extended.transfer(to, amount);
     }
 
@@ -819,7 +824,7 @@ contract ERC20Test is Test {
         ERC20Extended.approve(spender, amount);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount, amount + increment);
         ERC20Extended.transferFrom(owner, to, amount + increment);
     }
 
@@ -840,8 +845,9 @@ contract ERC20Test is Test {
 
     function testFuzzBurnInvalidAmount(address owner, uint256 amount) public {
         vm.assume(owner != deployer && owner != zeroAddress && amount != 0);
+        uint256 balance = ERC20Extended.balanceOf(owner);
         vm.prank(owner);
-        vm.expectRevert(bytes("erc20: burn amount exceeds balance"));
+        _expectInsufficientBalance(owner, balance, amount);
         ERC20Extended.burn(amount);
     }
 
@@ -874,7 +880,7 @@ contract ERC20Test is Test {
         ERC20Extended.approve(spender, amount);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc20: insufficient allowance"));
+        _expectInsufficientAllowance(spender, amount, amount + increment);
         ERC20Extended.burn_from(owner, amount + increment);
     }
 
@@ -893,7 +899,7 @@ contract ERC20Test is Test {
     }
 
     function testFuzzMintNonMinter(string calldata owner, uint256 amount) public {
-        vm.expectRevert(bytes("erc20: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC20Extended.mint(makeAddr(owner), amount);
     }
 
@@ -962,7 +968,7 @@ contract ERC20Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc20: invalid signature"));
+        _expectInvalidSigner(ownerAddr, spenderAddr, amount, deadline, v, r, s);
         ERC20Extended.permit(ownerAddr, spenderAddr, amount, deadline, v, r, s);
     }
 
@@ -1080,6 +1086,71 @@ contract ERC20Test is Test {
         vm.prank(nonOwner);
         vm.expectRevert(bytes("ownable: caller is not the owner"));
         ERC20Extended.renounce_ownership();
+    }
+
+    function _expectInsufficientBalance(address sender, uint256 balance, uint256 needed) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Extended.ERC20InsufficientBalance.selector, sender, balance, needed)
+        );
+    }
+
+    function _expectInvalidSender(address sender) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20InvalidSender.selector, sender));
+    }
+
+    function _expectInvalidReceiver(address receiver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20InvalidReceiver.selector, receiver));
+    }
+
+    function _expectInsufficientAllowance(address spender, uint256 allowance, uint256 needed) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Extended.ERC20InsufficientAllowance.selector, spender, allowance, needed)
+        );
+    }
+
+    function _expectInvalidApprover(address approver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20InvalidApprover.selector, approver));
+    }
+
+    function _expectInvalidSpender(address spender) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20InvalidSpender.selector, spender));
+    }
+
+    function _expectUnauthorizedMinter(address account) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20UnauthorizedMinter.selector, account));
+    }
+
+    function _expectInvalidMinter(address minter) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC20InvalidMinter.selector, minter));
+    }
+
+    function _expectInvalidSigner(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) private {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                hex"19_01",
+                ERC20Extended.DOMAIN_SEPARATOR(),
+                keccak256(abi.encode(_PERMIT_TYPE_HASH, owner, spender, amount, ERC20Extended.nonces(owner), deadline))
+            )
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Extended.ERC2612InvalidSigner.selector, ecrecover(digest, v, r, s), owner)
+        );
+    }
+
+    function _expectExpiredSignature(uint256 deadline) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.ERC2612ExpiredSignature.selector, deadline));
+    }
+
+    function _expectInvalidOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IOwnable.OwnableInvalidOwner.selector, owner));
     }
 }
 

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -17,6 +17,7 @@ import {Address} from "openzeppelin/utils/Address.sol";
 import {ERC721ReceiverMock} from "./mocks/ERC721ReceiverMock.sol";
 
 import {IERC721Extended} from "./interfaces/IERC721Extended.sol";
+import {IOwnable} from "../auth/interfaces/IOwnable.sol";
 
 contract ERC721Test is Test {
     string private constant _NAME = "MyNFT";
@@ -41,6 +42,7 @@ contract ERC721Test is Test {
     /* solhint-enable var-name-mixedcase */
 
     address private deployer = address(vyperDeployer);
+    address private self = address(this);
     address private zeroAddress = address(0);
     // solhint-disable-next-line var-name-mixedcase
     address private ERC721ExtendedAddr;
@@ -82,7 +84,7 @@ contract ERC721Test is Test {
         bytes memory data
     ) internal {
         vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc721: caller is not token owner or approved"));
+        _expectInsufficientApproval(makeAddr("nonOwner"), tokenId);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -97,7 +99,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer from incorrect owner"));
+        _expectIncorrectOwner(receiver, tokenId, owner);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -112,7 +114,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -127,7 +129,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -336,7 +338,7 @@ contract ERC721Test is Test {
         vm.revertToState(snapshot);
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         Address.functionCall(
             ERC721ExtendedAddr,
             abi.encodeWithSignature(transferFunction, owner, receiver, tokenId + 2, data)
@@ -426,7 +428,7 @@ contract ERC721Test is Test {
     }
 
     function testBalanceOfZeroAddress() public {
-        vm.expectRevert(bytes("erc721: the zero address is not a valid owner"));
+        _expectInvalidOwner(zeroAddress);
         ERC721Extended.balanceOf(zeroAddress);
     }
 
@@ -440,7 +442,7 @@ contract ERC721Test is Test {
     }
 
     function testOwnerOfInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.ownerOf(0);
     }
 
@@ -559,7 +561,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer to non-IERC721Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC721Extended.safeTransferFrom(owner, receiver, 0, new bytes(0));
         vm.stopPrank();
     }
@@ -768,7 +770,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: approval to current owner"));
+        _expectInvalidOperator(owner);
         ERC721Extended.approve(owner, tokenId);
         vm.stopPrank();
     }
@@ -782,7 +784,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(makeAddr("nonOwner"));
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -801,7 +803,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(spender);
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(spender);
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -837,7 +839,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 1);
         ERC721Extended.approve(makeAddr("to"), tokenId + 1);
         vm.stopPrank();
     }
@@ -916,13 +918,13 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: approve to caller"));
+        _expectInvalidOperator(owner);
         ERC721Extended.setApprovalForAll(owner, true);
         vm.stopPrank();
     }
 
     function testGetApprovedInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.getApproved(0);
     }
 
@@ -980,7 +982,7 @@ contract ERC721Test is Test {
     }
 
     function testTokenURIInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.tokenURI(0);
     }
 
@@ -995,7 +997,7 @@ contract ERC721Test is Test {
         ERC721Extended.burn(0);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.tokenURI(0);
     }
 
@@ -1052,7 +1054,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 2);
 
-        vm.expectRevert(bytes("erc721: global index out of bounds"));
+        _expectOutOfBoundsIndex(zeroAddress, 2);
         ERC721Extended.tokenByIndex(2);
     }
 
@@ -1107,7 +1109,7 @@ contract ERC721Test is Test {
         ERC721Extended.safe_mint(owner, uri3);
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 3);
-        vm.expectRevert(bytes("erc721: owner index out of bounds"));
+        _expectOutOfBoundsIndex(owner, tokenId + 3);
         ERC721Extended.tokenOfOwnerByIndex(owner, tokenId + 3);
 
         vm.startPrank(owner);
@@ -1116,7 +1118,7 @@ contract ERC721Test is Test {
         ERC721Extended.safeTransferFrom(owner, other, tokenId + 2, "");
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 3);
-        vm.expectRevert(bytes("erc721: owner index out of bounds"));
+        _expectOutOfBoundsIndex(owner, tokenId);
         ERC721Extended.tokenOfOwnerByIndex(owner, tokenId);
         assertEq(ERC721Extended.tokenOfOwnerByIndex(other, tokenId), tokenId);
         assertEq(ERC721Extended.tokenOfOwnerByIndex(other, tokenId + 1), tokenId + 1);
@@ -1137,11 +1139,11 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Transfer(owner, zeroAddress, tokenId);
         ERC721Extended.burn(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 1);
     }
@@ -1159,7 +1161,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         ERC721Extended.burn(tokenId + 2);
         ERC721Extended.setApprovalForAll(operator, true);
         ERC721Extended.approve(other, tokenId + 1);
@@ -1178,13 +1180,13 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.getApproved(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 0);
         assertEq(ERC721Extended.balanceOf(operator), 0);
@@ -1257,7 +1259,7 @@ contract ERC721Test is Test {
          * in Vyper, use `vyper -f layout your_filename.vy`.
          */
         vm.store(ERC721ExtendedAddr, bytes32(uint256(18_446_744_073_709_551_627)), bytes32(0));
-        vm.expectRevert(bytes("erc721: token already minted"));
+        _expectInvalidSender(zeroAddress);
         ERC721Extended.safe_mint(owner, "");
         vm.stopPrank();
     }
@@ -1284,7 +1286,7 @@ contract ERC721Test is Test {
         address owner = address(erc721ReceiverMock);
         string memory uri = "my_awesome_nft_uri";
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc721: transfer to non-IERC721Receiver implementer"));
+        _expectInvalidReceiver(owner);
         ERC721Extended.safe_mint(owner, uri);
         vm.stopPrank();
     }
@@ -1340,13 +1342,13 @@ contract ERC721Test is Test {
     }
 
     function testSafeMintNonMinter() public {
-        vm.expectRevert(bytes("erc721: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC721Extended.safe_mint(makeAddr("owner"), "my_awesome_nft_uri");
     }
 
     function testSafeMintToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: mint to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC721Extended.safe_mint(zeroAddress, "my_awesome_nft_uri");
     }
 
@@ -1384,13 +1386,13 @@ contract ERC721Test is Test {
 
     function testSetMinterToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: minter is the zero address"));
+        _expectInvalidMinter(zeroAddress);
         ERC721Extended.set_minter(zeroAddress, true);
     }
 
     function testSetMinterRemoveOwnerAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: minter is owner address"));
+        _expectInvalidMinter(deployer);
         ERC721Extended.set_minter(deployer, false);
     }
 
@@ -1448,7 +1450,7 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Approval(owner, spender, tokenId);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1474,7 +1476,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1508,7 +1510,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1534,7 +1536,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1560,7 +1562,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: expired deadline"));
+        _expectExpiredSignature(deadline);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1634,7 +1636,7 @@ contract ERC721Test is Test {
 
     function testTransferOwnershipToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: new owner is the zero address"));
+        _expectInvalidOwnershipOwner(zeroAddress);
         ERC721Extended.transfer_ownership(zeroAddress);
     }
 
@@ -1835,7 +1837,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(nonOwner);
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(nonOwner);
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -1937,11 +1939,11 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Transfer(owner, zeroAddress, tokenId);
         ERC721Extended.burn(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 1);
     }
@@ -1966,7 +1968,7 @@ contract ERC721Test is Test {
 
     function testFuzzSafeMintNonMinter(address nonOwner) public {
         vm.assume(nonOwner != deployer);
-        vm.expectRevert(bytes("erc721: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC721Extended.safe_mint(makeAddr("owner"), "my_awesome_nft_uri");
     }
 
@@ -2045,7 +2047,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spenderAddr, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spenderAddr, tokenId, deadline, v, r, s);
     }
 
@@ -2163,6 +2165,86 @@ contract ERC721Test is Test {
         vm.prank(nonOwner);
         vm.expectRevert(bytes("ownable: caller is not the owner"));
         ERC721Extended.renounce_ownership();
+    }
+
+    function _expectInsufficientApproval(address operator, uint256 tokenId) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC721Extended.ERC721InsufficientApproval.selector, operator, tokenId)
+        );
+    }
+
+    function _expectIncorrectOwner(address sender, uint256 tokenId, address owner) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC721Extended.ERC721IncorrectOwner.selector, sender, tokenId, owner)
+        );
+    }
+
+    function _expectNonexistentToken(uint256 tokenId) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721NonexistentToken.selector, tokenId));
+    }
+
+    function _expectInvalidReceiver(address receiver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidReceiver.selector, receiver));
+    }
+
+    function _expectInvalidOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidOwner.selector, owner));
+    }
+
+    function _expectInvalidOperator(address operator) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidOperator.selector, operator));
+    }
+
+    function _expectInvalidApprover(address approver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidApprover.selector, approver));
+    }
+
+    function _expectOutOfBoundsIndex(address owner, uint256 index) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721OutOfBoundsIndex.selector, owner, index));
+    }
+
+    function _expectInvalidSender(address sender) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidSender.selector, sender));
+    }
+
+    function _expectUnauthorizedMinter(address account) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721UnauthorizedMinter.selector, account));
+    }
+
+    function _expectInvalidMinter(address minter) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidMinter.selector, minter));
+    }
+
+    function _expectInvalidSigner(
+        address spender,
+        uint256 tokenId,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) private {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                hex"19_01",
+                ERC721Extended.DOMAIN_SEPARATOR(),
+                keccak256(abi.encode(_PERMIT_TYPE_HASH, spender, tokenId, ERC721Extended.nonces(tokenId), deadline))
+            )
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC4494.ERC4494InvalidSigner.selector,
+                ecrecover(digest, v, r, s),
+                ERC721Extended.ownerOf(tokenId)
+            )
+        );
+    }
+
+    function _expectExpiredSignature(uint256 deadline) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC4494.ERC4494ExpiredSignature.selector, deadline));
+    }
+
+    function _expectInvalidOwnershipOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IOwnable.OwnableInvalidOwner.selector, owner));
     }
 }
 

--- a/test/tokens/interfaces/IERC1155Extended.sol
+++ b/test/tokens/interfaces/IERC1155Extended.sol
@@ -8,6 +8,17 @@ interface IERC1155Extended is IERC1155MetadataURI {
 
     event RoleMinterChanged(address indexed minter, bool status);
 
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);
+    error ERC1155InvalidSender(address sender);
+    error ERC1155InvalidReceiver(address receiver);
+    error ERC1155MissingApprovalForAll(address operator, address owner);
+    error ERC1155InvalidApprover(address approver);
+    error ERC1155InvalidOperator(address operator);
+    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);
+    error ERC1155UnauthorizedMinter(address account);
+    error ERC1155InvalidMinter(address minter);
+    error ERC1155InsufficientSupply(address sender, uint256 supply, uint256 needed, uint256 tokenId);
+
     function set_uri(uint256 id, string calldata tokenUri) external;
 
     function exists(uint256 id) external view returns (bool);

--- a/test/tokens/interfaces/IERC20Extended.sol
+++ b/test/tokens/interfaces/IERC20Extended.sol
@@ -10,6 +10,17 @@ interface IERC20Extended is IERC20Metadata, IERC20Permit, IERC5267 {
 
     event RoleMinterChanged(address indexed minter, bool status);
 
+    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
+    error ERC20InvalidSender(address sender);
+    error ERC20InvalidReceiver(address receiver);
+    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
+    error ERC20InvalidApprover(address approver);
+    error ERC20InvalidSpender(address spender);
+    error ERC2612ExpiredSignature(uint256 deadline);
+    error ERC2612InvalidSigner(address signer, address owner);
+    error ERC20UnauthorizedMinter(address account);
+    error ERC20InvalidMinter(address minter);
+
     function burn(uint256 amount) external;
 
     function burn_from(address owner, uint256 amount) external;

--- a/test/tokens/interfaces/IERC4494.sol
+++ b/test/tokens/interfaces/IERC4494.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.36;
 import {IERC165} from "openzeppelin/utils/introspection/IERC165.sol";
 
 interface IERC4494 is IERC165 {
+    error ERC4494ExpiredSignature(uint256 deadline);
+    error ERC4494InvalidSigner(address signer, address owner);
+
     function permit(address spender, uint256 tokenId, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 
     function nonces(uint256 tokenId) external view returns (uint256);

--- a/test/tokens/interfaces/IERC721Extended.sol
+++ b/test/tokens/interfaces/IERC721Extended.sol
@@ -12,6 +12,18 @@ interface IERC721Extended is IERC721Metadata, IERC721Enumerable, IERC4494, IERC5
 
     event RoleMinterChanged(address indexed minter, bool status);
 
+    error ERC721InvalidOwner(address owner);
+    error ERC721NonexistentToken(uint256 tokenId);
+    error ERC721InvalidSender(address sender);
+    error ERC721InvalidReceiver(address receiver);
+    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
+    error ERC721InsufficientApproval(address operator, uint256 tokenId);
+    error ERC721InvalidApprover(address approver);
+    error ERC721InvalidOperator(address operator);
+    error ERC721OutOfBoundsIndex(address owner, uint256 index);
+    error ERC721UnauthorizedMinter(address account);
+    error ERC721InvalidMinter(address minter);
+
     function burn(uint256 tokenId) external;
 
     function is_minter(address minter) external view returns (bool);


### PR DESCRIPTION
### 🕓 Changelog

Migrate the `erc20`, `erc721`, and `erc1155` modules from string reverts to Vyper custom `error`s, following [ERC-6093](https://eips.ethereum.org/EIPS/eip-6093)/OpenZeppelin signatures where they exist.

- Add `IERC20Errors`, `IERC721Errors`, and `IERC1155Errors` interfaces and raise those errors from the token modules.
- Add `permit` and `enumerable` `error`s on the existing `IERC20Permit`, `IERC721Permit`, and `IERC721Enumerable` interfaces.
- Add module-local minter errors and `ERC1155InsufficientSupply`.
- Declare `OwnableInvalidOwner`/`OwnableUnauthorizedAccount` on `ownable.vy` so tokens can raise `OwnableInvalidOwner. ownable._check_owner()` still reverts with `"ownable: caller is not the owner"` (covered by #401).
- Update Foundry tests (including `erc4626` `permit`/`allowance` cases) to expect encoded custom error selectors.

#### 🐶 Cute Animal Picture

![manatee](https://images.pexels.com/photos/10962931/pexels-photo-10962931.jpeg)