### PR TITLE
💥 Migrate `erc721` to Custom `error`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 💥 New Features
 
+- **Tokens**
+  - [`erc721`](https://github.com/pcaversaccio/snekmate/blob/v0.1.3/src/snekmate/tokens/erc721.vy): Migrate `erc721` to custom `error`s. ([#407](https://github.com/pcaversaccio/snekmate/pull/407))
 - **Utility Functions**
   - [`eip7702_utils`](https://github.com/pcaversaccio/snekmate/blob/v0.1.3/src/snekmate/utils/eip7702_utils.vy): Add [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)-based utility functions. ([#335](https://github.com/pcaversaccio/snekmate/pull/335))
 

--- a/src/snekmate/auth/ownable.vy
+++ b/src/snekmate/auth/ownable.vy
@@ -31,6 +31,18 @@ event OwnershipTransferred:
     new_owner: indexed(address)
 
 
+# @dev The caller account is not authorized to
+# perform an operation.
+error OwnableUnauthorizedAccount:
+    account: address
+
+
+# @dev The owner is not a valid owner account.
+# (eg. `empty(address)`)
+error OwnableInvalidOwner:
+    owner: address
+
+
 @deploy
 @payable
 def __init__():

--- a/src/snekmate/auth/ownable.vy
+++ b/src/snekmate/auth/ownable.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title Owner-Based Access Control Functions

--- a/src/snekmate/tokens/erc721.vy
+++ b/src/snekmate/tokens/erc721.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title Modern and Gas-Efficient ERC-721 + EIP-4494 Implementation

--- a/src/snekmate/tokens/erc721.vy
+++ b/src/snekmate/tokens/erc721.vy
@@ -59,6 +59,10 @@ from ethereum.ercs import IERC721
 implements: IERC721
 
 
+# @dev We import the ERC-6093 custom error interface.
+from .interfaces import IERC721Errors
+
+
 # @dev We import and implement the `IERC721Metadata`
 # interface, which is written using standard Vyper
 # syntax.
@@ -246,6 +250,16 @@ event RoleMinterChanged:
     status: bool
 
 
+# @dev The caller is not an authorized `minter`.
+error ERC721UnauthorizedMinter:
+    account: address
+
+
+# @dev The `minter` address is invalid.
+error ERC721InvalidMinter:
+    minter: address
+
+
 @deploy
 @payable
 def __init__(
@@ -345,10 +359,10 @@ def approve(to: address, token_id: uint256):
     @param token_id The 32-byte identifier of the token.
     """
     owner: address = self._owner_of(token_id)
-    assert to != owner, "erc721: approval to current owner"
+    assert to != owner, IERC721Errors.ERC721InvalidOperator(operator=to)
     assert (
         msg.sender == owner or self.isApprovedForAll[owner][msg.sender]
-    ), "erc721: approve caller is not token owner or approved for all"
+    ), IERC721Errors.ERC721InvalidApprover(approver=msg.sender)
     self._approve(to, token_id)
 
 
@@ -406,7 +420,9 @@ def transferFrom(owner: address, to: address, token_id: uint256):
     @param to The 20-byte receiver address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._transfer(owner, to, token_id)
 
 
@@ -453,7 +469,9 @@ def safeTransferFrom(owner: address, to: address, token_id: uint256, data: Bytes
            with no specified format that is sent
            to `to`.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._safe_transfer(owner, to, token_id, data)
 
 
@@ -510,7 +528,9 @@ def tokenByIndex(index: uint256) -> uint256:
     @return uint256 The 32-byte token ID at index
             `index`.
     """
-    assert index < self._total_supply(), "erc721: global index out of bounds"
+    assert index < self._total_supply(), IERC721Enumerable.ERC721OutOfBoundsIndex(
+        owner=empty(address), index=index
+    )
     return self._all_tokens[index]
 
 
@@ -528,7 +548,9 @@ def tokenOfOwnerByIndex(owner: address, index: uint256) -> uint256:
     @return uint256 The 32-byte token ID owned by
             `owner` at index `index`.
     """
-    assert index < self._balance_of(owner), "erc721: owner index out of bounds"
+    assert index < self._balance_of(owner), IERC721Enumerable.ERC721OutOfBoundsIndex(
+        owner=owner, index=index
+    )
     return self._owned_tokens[owner][index]
 
 
@@ -540,7 +562,9 @@ def burn(token_id: uint256):
             or be an approved operator.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._is_approved_or_owner(msg.sender, token_id), "erc721: caller is not token owner or approved"
+    assert self._is_approved_or_owner(msg.sender, token_id), IERC721Errors.ERC721InsufficientApproval(
+        operator=msg.sender, tokenId=token_id
+    )
     self._burn(token_id)
 
 
@@ -556,7 +580,7 @@ def safe_mint(owner: address, uri: String[432]):
     @param uri The maximum 432-character user-readable
            string URI for computing `tokenURI`.
     """
-    assert self.is_minter[msg.sender], "erc721: access is denied"
+    assert self.is_minter[msg.sender], ERC721UnauthorizedMinter(account=msg.sender)
     # New tokens will be automatically assigned an incremental ID.
     # The first token ID will be zero.
     token_id: uint256 = self._counter
@@ -584,10 +608,10 @@ def set_minter(minter: address, status: bool):
     @param status The Boolean variable that sets the status.
     """
     ownable._check_owner()
-    assert minter != empty(address), "erc721: minter is the zero address"
+    assert minter != empty(address), ERC721InvalidMinter(minter=minter)
     # We ensured in the previous step `ownable._check_owner`
     # that `msg.sender` is the `owner`.
-    assert minter != msg.sender, "erc721: minter is owner address"
+    assert minter != msg.sender, ERC721InvalidMinter(minter=minter)
     self.is_minter[minter] = status
     log RoleMinterChanged(minter=minter, status=status)
 
@@ -612,7 +636,7 @@ def permit(spender: address, token_id: uint256, deadline: uint256, v: uint8, r: 
     @param r The secp256k1 32-byte signature parameter `r`.
     @param s The secp256k1 32-byte signature parameter `s`.
     """
-    assert block.timestamp <= deadline, "erc721: expired deadline"
+    assert block.timestamp <= deadline, IERC721Permit.ERC4494ExpiredSignature(deadline=deadline)
 
     current_nonce: uint256 = self.nonces[token_id]
     self.nonces[token_id] = unsafe_add(current_nonce, 1)
@@ -621,7 +645,9 @@ def permit(spender: address, token_id: uint256, deadline: uint256, v: uint8, r: 
     hash: bytes32 = eip712_domain_separator._hash_typed_data_v4(struct_hash)
 
     signer: address = ecdsa._recover_vrs(hash, convert(v, uint256), convert(r, uint256), convert(s, uint256))
-    assert signer == self._owner_of(token_id), "erc721: invalid signature"
+    assert signer == self._owner_of(token_id), IERC721Permit.ERC4494InvalidSigner(
+        signer=signer, owner=self._owner_of(token_id)
+    )
 
     self._approve(spender, token_id)
 
@@ -651,7 +677,7 @@ def transfer_ownership(new_owner: address):
     @param new_owner The 20-byte address of the new owner.
     """
     ownable._check_owner()
-    assert new_owner != empty(address), "erc721: new owner is the zero address"
+    assert new_owner != empty(address), ownable.OwnableInvalidOwner(owner=new_owner)
 
     self.is_minter[msg.sender] = False
     log RoleMinterChanged(minter=msg.sender, status=False)
@@ -695,7 +721,7 @@ def _balance_of(owner: address) -> uint256:
     @return uint256 The 32-byte token amount owned
             by `owner`.
     """
-    assert owner != empty(address), "erc721: the zero address is not a valid owner"
+    assert owner != empty(address), IERC721Errors.ERC721InvalidOwner(owner=owner)
     return self._balances[owner]
 
 
@@ -710,7 +736,7 @@ def _owner_of(token_id: uint256) -> address:
     @return address The 20-byte owner address.
     """
     owner: address = self._owners[token_id]
-    assert owner != empty(address), "erc721: invalid token ID"
+    assert owner != empty(address), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
     return owner
 
 
@@ -721,7 +747,7 @@ def _require_minted(token_id: uint256):
     @dev Reverts if the `token_id` has not yet been minted.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._exists(token_id), "erc721: invalid token ID"
+    assert self._exists(token_id), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
 
 
 @internal
@@ -774,7 +800,7 @@ def _set_approval_for_all(owner: address, operator: address, approved: bool):
     @param approved The Boolean variable that sets the
            approval status.
     """
-    assert owner != operator, "erc721: approve to caller"
+    assert owner != operator, IERC721Errors.ERC721InvalidOperator(operator=operator)
     self.isApprovedForAll[owner][operator] = approved
     log IERC721.ApprovalForAll(owner=owner, operator=operator, approved=approved)
 
@@ -817,7 +843,7 @@ def _safe_mint(owner: address, token_id: uint256, data: Bytes[1_024]):
     self._mint(owner, token_id)
     assert self._check_on_erc721_received(
         empty(address), owner, token_id, data
-    ), "erc721: transfer to non-IERC721Receiver implementer"
+    ), IERC721Errors.ERC721InvalidReceiver(receiver=owner)
 
 
 @internal
@@ -832,13 +858,13 @@ def _mint(owner: address, token_id: uint256):
     @param owner The 20-byte owner address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert owner != empty(address), "erc721: mint to the zero address"
-    assert not self._exists(token_id), "erc721: token already minted"
+    assert owner != empty(address), IERC721Errors.ERC721InvalidReceiver(receiver=owner)
+    assert not self._exists(token_id), IERC721Errors.ERC721InvalidSender(sender=empty(address))
 
     self._before_token_transfer(empty(address), owner, token_id)
     # Checks that the `token_id` was not minted by the
     # `_before_token_transfer` hook.
-    assert not self._exists(token_id), "erc721: token already minted"
+    assert not self._exists(token_id), IERC721Errors.ERC721InvalidSender(sender=empty(address))
 
     # Theoretically, the following line could overflow
     # if all 2**256 token IDs were minted to the same owner.
@@ -887,7 +913,7 @@ def _safe_transfer(owner: address, to: address, token_id: uint256, data: Bytes[1
     self._transfer(owner, to, token_id)
     assert self._check_on_erc721_received(
         owner, to, token_id, data
-    ), "erc721: transfer to non-IERC721Receiver implementer"
+    ), IERC721Errors.ERC721InvalidReceiver(receiver=to)
 
 
 @internal
@@ -903,13 +929,19 @@ def _transfer(owner: address, to: address, token_id: uint256):
     @param to The 20-byte receiver address.
     @param token_id The 32-byte identifier of the token.
     """
-    assert self._owner_of(token_id) == owner, "erc721: transfer from incorrect owner"
-    assert to != empty(address), "erc721: transfer to the zero address"
+    current_owner: address = self._owner_of(token_id)
+    assert current_owner == owner, IERC721Errors.ERC721IncorrectOwner(
+        sender=owner, tokenId=token_id, owner=current_owner
+    )
+    assert to != empty(address), IERC721Errors.ERC721InvalidReceiver(receiver=to)
 
     self._before_token_transfer(owner, to, token_id)
     # Checks that the `token_id` was not transferred by the
     # `_before_token_transfer` hook.
-    assert self._owner_of(token_id) == owner, "erc721: transfer from incorrect owner"
+    current_owner = self._owner_of(token_id)
+    assert current_owner == owner, IERC721Errors.ERC721IncorrectOwner(
+        sender=owner, tokenId=token_id, owner=current_owner
+    )
 
     self._token_approvals[token_id] = empty(address)
     # See comment why an overflow is not possible in the
@@ -931,7 +963,7 @@ def _set_token_uri(token_id: uint256, token_uri: String[432]):
     @param token_uri The maximum 432-character user-readable
            string URI for computing `tokenURI`.
     """
-    assert self._exists(token_id), "erc721: URI set of nonexistent token"
+    assert self._exists(token_id), IERC721Errors.ERC721NonexistentToken(tokenId=token_id)
     self._token_uris[token_id] = token_uri
     log IERC4906.MetadataUpdate(_tokenId=token_id)
 
@@ -1000,7 +1032,7 @@ def _check_on_erc721_received(owner: address, to: address, token_id: uint256, da
         return_value: bytes4 = extcall IERC721Receiver(to).onERC721Received(msg.sender, owner, token_id, data)
         assert return_value == method_id(
             "onERC721Received(address,address,uint256,bytes)", output_type=bytes4
-        ), "erc721: transfer to non-IERC721Receiver implementer"
+        ), IERC721Errors.ERC721InvalidReceiver(receiver=to)
         return True
 
     # EOA case.

--- a/src/snekmate/tokens/interfaces/IERC4906.vyi
+++ b/src/snekmate/tokens/interfaces/IERC4906.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-4906 Interface Definition
 @custom:contract-name IERC4906

--- a/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
@@ -33,6 +33,13 @@ implements: IERC165
 from ethereum.ercs import IERC721
 
 
+# @dev The requested index is outside the token collection
+# or owner's token list.
+error ERC721OutOfBoundsIndex:
+  owner: address
+  index: uint256
+
+
 @external
 @view
 def supportsInterface(interfaceId: bytes4) -> bool:

--- a/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Enumerable.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-721 Optional Enumeration Interface Definition
 @custom:contract-name IERC721Enumerable

--- a/src/snekmate/tokens/interfaces/IERC721Errors.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Errors.vyi
@@ -1,0 +1,57 @@
+# pragma version ~=0.5.0a4
+"""
+@title ERC-721 Custom Error Interface Definition
+@custom:contract-name IERC721Errors
+@license GNU Affero General Public License v3.0 only
+@author rafael-abuawad
+@notice The custom errors defined by ERC-6093 for
+        ERC-721 tokens. For more details, please
+        refer to:
+        https://eips.ethereum.org/EIPS/eip-6093#erc-721.
+
+        On how to use interfaces in Vyper, please visit:
+        https://vyper.readthedocs.io/en/latest/interfaces.html#interfaces.
+"""
+
+
+# @dev The `owner` is not a valid token owner.
+error ERC721InvalidOwner:
+  owner: address
+
+
+# @dev The `tokenId` does not identify an existing token.
+error ERC721NonexistentToken:
+  tokenId: uint256
+
+
+# @dev The `sender` is not a valid token sender.
+error ERC721InvalidSender:
+  sender: address
+
+
+# @dev The `receiver` is not a valid token receiver.
+error ERC721InvalidReceiver:
+  receiver: address
+
+
+# @dev The transfer is from an incorrect owner.
+error ERC721IncorrectOwner:
+  sender: address
+  tokenId: uint256
+  owner: address
+
+
+# @dev The `operator` is not approved for the token.
+error ERC721InsufficientApproval:
+  operator: address
+  tokenId: uint256
+
+
+# @dev The `approver` is not a valid token approver.
+error ERC721InvalidApprover:
+  approver: address
+
+
+# @dev The `operator` is not a valid token operator.
+error ERC721InvalidOperator:
+  operator: address

--- a/src/snekmate/tokens/interfaces/IERC721Metadata.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Metadata.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-721 Optional Metadata Interface Definition
 @custom:contract-name IERC721Metadata

--- a/src/snekmate/tokens/interfaces/IERC721Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Permit.vyi
@@ -34,6 +34,17 @@ from ethereum.ercs import IERC165
 implements: IERC165
 
 
+# @dev The permit deadline has expired.
+error ERC4494ExpiredSignature:
+  deadline: uint256
+
+
+# @dev The permit signature does not match the owner.
+error ERC4494InvalidSigner:
+  signer: address
+  owner: address
+
+
 @external
 @view
 def supportsInterface(interfaceId: bytes4) -> bool:

--- a/src/snekmate/tokens/interfaces/IERC721Permit.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Permit.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-4494 Interface Definition
 @custom:contract-name IERC721Permit

--- a/src/snekmate/tokens/interfaces/IERC721Receiver.vyi
+++ b/src/snekmate/tokens/interfaces/IERC721Receiver.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-721 Token Receiver Interface Definition
 @custom:contract-name IERC721Receiver

--- a/src/snekmate/tokens/mocks/erc721_mock.vy
+++ b/src/snekmate/tokens/mocks/erc721_mock.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title `erc721` Module Reference Implementation

--- a/src/snekmate/utils/ecdsa.vy
+++ b/src/snekmate/utils/ecdsa.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title Elliptic Curve Digital Signature Algorithm (ECDSA) Secp256k1-Based Functions

--- a/src/snekmate/utils/eip712_domain_separator.vy
+++ b/src/snekmate/utils/eip712_domain_separator.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title EIP-712 Domain Separator

--- a/src/snekmate/utils/interfaces/IERC5267.vyi
+++ b/src/snekmate/utils/interfaces/IERC5267.vyi
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 """
 @title EIP-5267 Interface Definition
 @custom:contract-name IERC5267

--- a/src/snekmate/utils/message_hash_utils.vy
+++ b/src/snekmate/utils/message_hash_utils.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.3
+# pragma version ~=0.5.0a4
 # pragma nonreentrancy off
 """
 @title Signature Message Hash Utility Functions

--- a/test/auth/interfaces/IOwnable.sol
+++ b/test/auth/interfaces/IOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: WTFPL
-pragma solidity ^0.8.34;
+pragma solidity ^0.8.36;
 
 interface IOwnable {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);

--- a/test/auth/interfaces/IOwnable.sol
+++ b/test/auth/interfaces/IOwnable.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.34;
 interface IOwnable {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
+    error OwnableUnauthorizedAccount(address account);
+    error OwnableInvalidOwner(address owner);
+
     function owner() external view returns (address);
 
     function transfer_ownership(address newOwner) external;

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: WTFPL
-pragma solidity ^0.8.34;
+pragma solidity ^0.8.36;
 
 import {Test} from "forge-std/Test.sol";
 import {stdError} from "forge-std/StdError.sol";

--- a/test/tokens/ERC721.t.sol
+++ b/test/tokens/ERC721.t.sol
@@ -17,6 +17,7 @@ import {Address} from "openzeppelin/utils/Address.sol";
 import {ERC721ReceiverMock} from "./mocks/ERC721ReceiverMock.sol";
 
 import {IERC721Extended} from "./interfaces/IERC721Extended.sol";
+import {IOwnable} from "../auth/interfaces/IOwnable.sol";
 
 contract ERC721Test is Test {
     string private constant _NAME = "MyNFT";
@@ -41,6 +42,7 @@ contract ERC721Test is Test {
     /* solhint-enable var-name-mixedcase */
 
     address private deployer = address(vyperDeployer);
+    address private self = address(this);
     address private zeroAddress = address(0);
     // solhint-disable-next-line var-name-mixedcase
     address private ERC721ExtendedAddr;
@@ -82,7 +84,7 @@ contract ERC721Test is Test {
         bytes memory data
     ) internal {
         vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc721: caller is not token owner or approved"));
+        _expectInsufficientApproval(makeAddr("nonOwner"), tokenId);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -97,7 +99,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer from incorrect owner"));
+        _expectIncorrectOwner(receiver, tokenId, owner);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -112,7 +114,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -127,7 +129,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         if (!withData) {
             Address.functionCall(
                 ERC721ExtendedAddr,
@@ -336,7 +338,7 @@ contract ERC721Test is Test {
         vm.revertToState(snapshot);
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         Address.functionCall(
             ERC721ExtendedAddr,
             abi.encodeWithSignature(transferFunction, owner, receiver, tokenId + 2, data)
@@ -426,7 +428,7 @@ contract ERC721Test is Test {
     }
 
     function testBalanceOfZeroAddress() public {
-        vm.expectRevert(bytes("erc721: the zero address is not a valid owner"));
+        _expectInvalidOwner(zeroAddress);
         ERC721Extended.balanceOf(zeroAddress);
     }
 
@@ -440,7 +442,7 @@ contract ERC721Test is Test {
     }
 
     function testOwnerOfInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.ownerOf(0);
     }
 
@@ -559,7 +561,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: transfer to non-IERC721Receiver implementer"));
+        _expectInvalidReceiver(receiver);
         ERC721Extended.safeTransferFrom(owner, receiver, 0, new bytes(0));
         vm.stopPrank();
     }
@@ -768,7 +770,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: approval to current owner"));
+        _expectInvalidOperator(owner);
         ERC721Extended.approve(owner, tokenId);
         vm.stopPrank();
     }
@@ -782,7 +784,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(makeAddr("nonOwner"));
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(makeAddr("nonOwner"));
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -801,7 +803,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(spender);
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(spender);
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -837,7 +839,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 1);
         ERC721Extended.approve(makeAddr("to"), tokenId + 1);
         vm.stopPrank();
     }
@@ -916,13 +918,13 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: approve to caller"));
+        _expectInvalidOperator(owner);
         ERC721Extended.setApprovalForAll(owner, true);
         vm.stopPrank();
     }
 
     function testGetApprovedInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.getApproved(0);
     }
 
@@ -980,7 +982,7 @@ contract ERC721Test is Test {
     }
 
     function testTokenURIInvalidTokenId() public {
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.tokenURI(0);
     }
 
@@ -995,7 +997,7 @@ contract ERC721Test is Test {
         ERC721Extended.burn(0);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(0);
         ERC721Extended.tokenURI(0);
     }
 
@@ -1052,7 +1054,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 2);
 
-        vm.expectRevert(bytes("erc721: global index out of bounds"));
+        _expectOutOfBoundsIndex(zeroAddress, 2);
         ERC721Extended.tokenByIndex(2);
     }
 
@@ -1107,7 +1109,7 @@ contract ERC721Test is Test {
         ERC721Extended.safe_mint(owner, uri3);
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 3);
-        vm.expectRevert(bytes("erc721: owner index out of bounds"));
+        _expectOutOfBoundsIndex(owner, tokenId + 3);
         ERC721Extended.tokenOfOwnerByIndex(owner, tokenId + 3);
 
         vm.startPrank(owner);
@@ -1116,7 +1118,7 @@ contract ERC721Test is Test {
         ERC721Extended.safeTransferFrom(owner, other, tokenId + 2, "");
         vm.stopPrank();
         assertEq(ERC721Extended.totalSupply(), 3);
-        vm.expectRevert(bytes("erc721: owner index out of bounds"));
+        _expectOutOfBoundsIndex(owner, tokenId);
         ERC721Extended.tokenOfOwnerByIndex(owner, tokenId);
         assertEq(ERC721Extended.tokenOfOwnerByIndex(other, tokenId), tokenId);
         assertEq(ERC721Extended.tokenOfOwnerByIndex(other, tokenId + 1), tokenId + 1);
@@ -1137,11 +1139,11 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Transfer(owner, zeroAddress, tokenId);
         ERC721Extended.burn(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 1);
     }
@@ -1159,7 +1161,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId + 2);
         ERC721Extended.burn(tokenId + 2);
         ERC721Extended.setApprovalForAll(operator, true);
         ERC721Extended.approve(other, tokenId + 1);
@@ -1178,13 +1180,13 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(owner);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.getApproved(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 0);
         assertEq(ERC721Extended.balanceOf(operator), 0);
@@ -1257,7 +1259,7 @@ contract ERC721Test is Test {
          * in Vyper, use `vyper -f layout your_filename.vy`.
          */
         vm.store(ERC721ExtendedAddr, bytes32(uint256(18_446_744_073_709_551_627)), bytes32(0));
-        vm.expectRevert(bytes("erc721: token already minted"));
+        _expectInvalidSender(zeroAddress);
         ERC721Extended.safe_mint(owner, "");
         vm.stopPrank();
     }
@@ -1284,7 +1286,7 @@ contract ERC721Test is Test {
         address owner = address(erc721ReceiverMock);
         string memory uri = "my_awesome_nft_uri";
         vm.startPrank(deployer);
-        vm.expectRevert(bytes("erc721: transfer to non-IERC721Receiver implementer"));
+        _expectInvalidReceiver(owner);
         ERC721Extended.safe_mint(owner, uri);
         vm.stopPrank();
     }
@@ -1340,13 +1342,13 @@ contract ERC721Test is Test {
     }
 
     function testSafeMintNonMinter() public {
-        vm.expectRevert(bytes("erc721: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC721Extended.safe_mint(makeAddr("owner"), "my_awesome_nft_uri");
     }
 
     function testSafeMintToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: mint to the zero address"));
+        _expectInvalidReceiver(zeroAddress);
         ERC721Extended.safe_mint(zeroAddress, "my_awesome_nft_uri");
     }
 
@@ -1384,13 +1386,13 @@ contract ERC721Test is Test {
 
     function testSetMinterToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: minter is the zero address"));
+        _expectInvalidMinter(zeroAddress);
         ERC721Extended.set_minter(zeroAddress, true);
     }
 
     function testSetMinterRemoveOwnerAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: minter is owner address"));
+        _expectInvalidMinter(deployer);
         ERC721Extended.set_minter(deployer, false);
     }
 
@@ -1448,7 +1450,7 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Approval(owner, spender, tokenId);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1474,7 +1476,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1508,7 +1510,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1534,7 +1536,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spender, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1560,7 +1562,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: expired deadline"));
+        _expectExpiredSignature(deadline);
         ERC721Extended.permit(spender, tokenId, deadline, v, r, s);
     }
 
@@ -1634,7 +1636,7 @@ contract ERC721Test is Test {
 
     function testTransferOwnershipToZeroAddress() public {
         vm.prank(deployer);
-        vm.expectRevert(bytes("erc721: new owner is the zero address"));
+        _expectInvalidOwnershipOwner(zeroAddress);
         ERC721Extended.transfer_ownership(zeroAddress);
     }
 
@@ -1835,7 +1837,7 @@ contract ERC721Test is Test {
         vm.stopPrank();
 
         vm.startPrank(nonOwner);
-        vm.expectRevert(bytes("erc721: approve caller is not token owner or approved for all"));
+        _expectInvalidApprover(nonOwner);
         ERC721Extended.approve(makeAddr("to"), tokenId);
         vm.stopPrank();
     }
@@ -1937,11 +1939,11 @@ contract ERC721Test is Test {
         vm.expectEmit(true, true, true, false);
         emit IERC721.Transfer(owner, zeroAddress, tokenId);
         ERC721Extended.burn(tokenId);
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.burn(tokenId);
         vm.stopPrank();
 
-        vm.expectRevert(bytes("erc721: invalid token ID"));
+        _expectNonexistentToken(tokenId);
         ERC721Extended.ownerOf(tokenId);
         assertEq(ERC721Extended.balanceOf(owner), 1);
     }
@@ -1966,7 +1968,7 @@ contract ERC721Test is Test {
 
     function testFuzzSafeMintNonMinter(address nonOwner) public {
         vm.assume(nonOwner != deployer);
-        vm.expectRevert(bytes("erc721: access is denied"));
+        _expectUnauthorizedMinter(self);
         ERC721Extended.safe_mint(makeAddr("owner"), "my_awesome_nft_uri");
     }
 
@@ -2045,7 +2047,7 @@ contract ERC721Test is Test {
                 )
             )
         );
-        vm.expectRevert(bytes("erc721: invalid signature"));
+        _expectInvalidSigner(spenderAddr, tokenId, deadline, v, r, s);
         ERC721Extended.permit(spenderAddr, tokenId, deadline, v, r, s);
     }
 
@@ -2163,6 +2165,86 @@ contract ERC721Test is Test {
         vm.prank(nonOwner);
         vm.expectRevert(bytes("ownable: caller is not the owner"));
         ERC721Extended.renounce_ownership();
+    }
+
+    function _expectInsufficientApproval(address operator, uint256 tokenId) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC721Extended.ERC721InsufficientApproval.selector, operator, tokenId)
+        );
+    }
+
+    function _expectIncorrectOwner(address sender, uint256 tokenId, address owner) private {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC721Extended.ERC721IncorrectOwner.selector, sender, tokenId, owner)
+        );
+    }
+
+    function _expectNonexistentToken(uint256 tokenId) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721NonexistentToken.selector, tokenId));
+    }
+
+    function _expectInvalidReceiver(address receiver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidReceiver.selector, receiver));
+    }
+
+    function _expectInvalidOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidOwner.selector, owner));
+    }
+
+    function _expectInvalidOperator(address operator) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidOperator.selector, operator));
+    }
+
+    function _expectInvalidApprover(address approver) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidApprover.selector, approver));
+    }
+
+    function _expectOutOfBoundsIndex(address owner, uint256 index) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721OutOfBoundsIndex.selector, owner, index));
+    }
+
+    function _expectInvalidSender(address sender) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidSender.selector, sender));
+    }
+
+    function _expectUnauthorizedMinter(address account) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721UnauthorizedMinter.selector, account));
+    }
+
+    function _expectInvalidMinter(address minter) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Extended.ERC721InvalidMinter.selector, minter));
+    }
+
+    function _expectInvalidSigner(
+        address spender,
+        uint256 tokenId,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) private {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                hex"19_01",
+                ERC721Extended.DOMAIN_SEPARATOR(),
+                keccak256(abi.encode(_PERMIT_TYPE_HASH, spender, tokenId, ERC721Extended.nonces(tokenId), deadline))
+            )
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC4494.ERC4494InvalidSigner.selector,
+                ecrecover(digest, v, r, s),
+                ERC721Extended.ownerOf(tokenId)
+            )
+        );
+    }
+
+    function _expectExpiredSignature(uint256 deadline) private {
+        vm.expectRevert(abi.encodeWithSelector(IERC4494.ERC4494ExpiredSignature.selector, deadline));
+    }
+
+    function _expectInvalidOwnershipOwner(address owner) private {
+        vm.expectRevert(abi.encodeWithSelector(IOwnable.OwnableInvalidOwner.selector, owner));
     }
 }
 

--- a/test/tokens/interfaces/IERC4494.sol
+++ b/test/tokens/interfaces/IERC4494.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.34;
 import {IERC165} from "openzeppelin/utils/introspection/IERC165.sol";
 
 interface IERC4494 is IERC165 {
+    error ERC4494ExpiredSignature(uint256 deadline);
+    error ERC4494InvalidSigner(address signer, address owner);
+
     function permit(address spender, uint256 tokenId, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 
     function nonces(uint256 tokenId) external view returns (uint256);

--- a/test/tokens/interfaces/IERC4494.sol
+++ b/test/tokens/interfaces/IERC4494.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: WTFPL
-pragma solidity ^0.8.34;
+pragma solidity ^0.8.36;
 
 import {IERC165} from "openzeppelin/utils/introspection/IERC165.sol";
 

--- a/test/tokens/interfaces/IERC721Extended.sol
+++ b/test/tokens/interfaces/IERC721Extended.sol
@@ -12,6 +12,18 @@ interface IERC721Extended is IERC721Metadata, IERC721Enumerable, IERC4494, IERC5
 
     event RoleMinterChanged(address indexed minter, bool status);
 
+    error ERC721InvalidOwner(address owner);
+    error ERC721NonexistentToken(uint256 tokenId);
+    error ERC721InvalidSender(address sender);
+    error ERC721InvalidReceiver(address receiver);
+    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
+    error ERC721InsufficientApproval(address operator, uint256 tokenId);
+    error ERC721InvalidApprover(address approver);
+    error ERC721InvalidOperator(address operator);
+    error ERC721OutOfBoundsIndex(address owner, uint256 index);
+    error ERC721UnauthorizedMinter(address account);
+    error ERC721InvalidMinter(address minter);
+
     function burn(uint256 tokenId) external;
 
     function is_minter(address minter) external view returns (bool);

--- a/test/tokens/interfaces/IERC721Extended.sol
+++ b/test/tokens/interfaces/IERC721Extended.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: WTFPL
-pragma solidity ^0.8.34;
+pragma solidity ^0.8.36;
 
 import {IERC721Metadata} from "openzeppelin/token/ERC721/extensions/IERC721Metadata.sol";
 import {IERC721Enumerable} from "openzeppelin/token/ERC721/extensions/IERC721Enumerable.sol";


### PR DESCRIPTION
### 🕓 Changelog

Migrate the `erc721` module from string reverts to Vyper custom `error`s, following [ERC-6093](https://eips.ethereum.org/EIPS/eip-6093)/OpenZeppelin signatures where they exist.

- Add `IERC721Errors` interface and raise those `error`s from the `erc721` module.
- Add `permit` `error`s on the existing `IERC721Permit` interface.
- Add `enumerable` `error`s on the existing `IERC721Enumerable` interface.
- Add module-local minter errors.
- Declare `OwnableInvalidOwner`/`OwnableUnauthorizedAccount` on `ownable.vy` so `erc721` can raise `OwnableInvalidOwner`. `ownable._check_owner()` still reverts with `"ownable: caller is not the owner"` (covered by #401).

#### 🐶 Cute Animal Picture

![viscacha](https://static.boredpanda.com/blog/wp-content/uploads/2021/02/southern-viscacha-sleepy-dissatisfied-6021128fdb6e3__700.jpg)